### PR TITLE
Implement Lane D finalize workflow with canonical records

### DIFF
--- a/.github/workflows/leaderboard-finalize.yml
+++ b/.github/workflows/leaderboard-finalize.yml
@@ -1,0 +1,79 @@
+name: Leaderboard Finalize
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - leaderboard-submissions
+
+permissions:
+  contents: write
+
+jobs:
+  finalize:
+    name: Finalize merged leaderboard submission
+    if: ${{ github.event.pull_request.merged == true }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: leaderboard-finalize-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout leaderboard-submissions
+        uses: actions/checkout@v4
+        with:
+          ref: leaderboard-submissions
+          fetch-depth: 0
+
+      - name: Setup environment
+        uses: ./.github/actions/setup
+        with:
+          sync-args: --group dev
+          configure-git-identity: "true"
+
+      - name: Resolve finalize settings
+        id: cfg
+        run: |
+          set -euo pipefail
+          HF_REPO="${{ vars.LEADERBOARD_HF_REPO }}"
+          if [ -z "$HF_REPO" ]; then
+            echo "Missing repository variable LEADERBOARD_HF_REPO"
+            exit 1
+          fi
+
+          EVALUATOR_VERSION="${{ vars.LEADERBOARD_EVALUATOR_VERSION }}"
+
+          echo "hf_repo=$HF_REPO" >> "$GITHUB_OUTPUT"
+          echo "evaluator_version=$EVALUATOR_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Run finalize processor
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          set -euo pipefail
+          uv run inv dev.leaderboard.finalize \
+            --event-path "$GITHUB_EVENT_PATH" \
+            --github-repo "${{ github.repository }}" \
+            --hf-repo "${{ steps.cfg.outputs.hf_repo }}" \
+            --github-token "$GITHUB_TOKEN" \
+            --hf-token "$HF_TOKEN" \
+            --evaluator-version "${{ steps.cfg.outputs.evaluator_version }}"
+
+      - name: Commit and push finalized state
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- submissions; then
+            echo "No submission changes detected after finalize"
+            exit 0
+          fi
+          git add submissions
+          git commit -m "Finalize leaderboard submission #${{ github.event.pull_request.number }}"
+          git push origin HEAD:leaderboard-submissions
+
+      - name: Finalize summary
+        run: |
+          echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "submission_id=${{ github.event.pull_request.number }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "hf_repo=${{ steps.cfg.outputs.hf_repo }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "handoff=push trigger on submissions/*.json" >> "$GITHUB_STEP_SUMMARY"

--- a/.wip/lane-d-finalize.md
+++ b/.wip/lane-d-finalize.md
@@ -2,34 +2,210 @@
 
 ## Goal
 
-After merge, canonicalize submission, persist to HF, and write canonical record.
+After merge, canonicalize one intake submission, upload canonical payload to HF, write `submissions/<submission_id>.json`, and clean `submissions/inbox/<intake_id>/`.
 
-## Tasks
+This lane uses a **push-triggered handoff** to Lane E: rebuild runs when finalize commits canonical record changes.
+
+## Scope and non-goals
+
+- In scope: merged PR finalization on `leaderboard-submissions`.
+- In scope: one canonical record per merged intake PR.
+- In scope: deterministic `submission_id = github_pr_number`.
+- Out of scope: leaderboard file generation (owned by Lane E).
+- Out of scope: policy/ruleset enforcement (owned by Lane A).
+
+## Workflow design
+
+### D01 Finalize trigger
+
+Create `.github/workflows/leaderboard-finalize.yml`.
+
+- Trigger:
+  - `on.pull_request.types: [closed]`
+  - `on.pull_request.branches: [leaderboard-submissions]`
+- Job guard:
+  - `if: github.event.pull_request.merged == true`
+- Permissions:
+  - `contents: write`
+- Concurrency:
+  - `group: leaderboard-finalize-${{ github.event.pull_request.number }}`
+  - `cancel-in-progress: false`
+
+### D07 Rebuild trigger by push (selected)
+
+Lane E workflow listens to push updates written by finalize.
+
+- `on.push.branches: [leaderboard-submissions]`
+- `on.push.paths:`
+  - `submissions/*.json`
+
+This keeps coupling simple and avoids dispatch permissions.
+
+## Module plan and function signatures
+
+Add `dev/leaderboard/finalize.py` as the finalize entrypoint.
+
+```python
+from pathlib import Path
+from pydantic import BaseModel
+
+class FinalizeContext(BaseModel):
+    pr_number: int
+    pr_url: str
+    merge_commit_sha: str
+    source_repository_id: int
+    source_repository_full_name: str
+    github_pr_author_id: int
+    github_pr_author_login: str
+
+class HFPersistResult(BaseModel):
+    hf_repo: str
+    hf_path: str
+    hf_revision: str
+
+class FinalizeResult(BaseModel):
+    submission_id: str
+    intake_id: str
+    canonical_record_path: str
+    deleted_inbox_path: str
+    hf_repo: str
+    hf_path: str
+    hf_revision: str
+
+def parse_finalize_event(event_path: Path) -> FinalizeContext: ...
+def list_merged_pr_changed_files(repo: str, pr_number: int, token: str) -> list[str]: ...
+def resolve_single_intake_id(changed_files: list[str]) -> str: ...
+def load_intake_payload(repo_root: Path, intake_id: str) -> tuple[dict, dict]: ...
+def run_evaluation(repo_root: Path, intake_id: str, evaluator_version: str) -> dict: ...
+def persist_payload_to_hf(*, repo_root: Path, intake_id: str, submission_id: str, hf_repo: str, hf_token: str) -> HFPersistResult: ...
+def build_canonical_record(*, context: FinalizeContext, submission_id: str, intake_submission: dict, eval_summary: dict, hf_result: HFPersistResult, now_utc: str) -> dict: ...
+def write_canonical_record(*, repo_root: Path, submission_id: str, record: dict) -> Path: ...
+def delete_inbox_folder(*, repo_root: Path, intake_id: str) -> Path: ...
+def finalize_submission(*, repo_root: Path, event_path: Path, github_repo: str, github_token: str, hf_repo: str, hf_token: str, evaluator_version: str) -> FinalizeResult: ...
+```
+
+Add invoke task in `dev/leaderboard_tasks.py`:
+
+```python
+@task(name="finalize")
+def finalize_task(
+    _ctx: Context,
+    event_path: str,
+    github_repo: str,
+    hf_repo: str,
+    github_token: str = "",
+    hf_token: str = "",
+    evaluator_version: str = "",
+) -> None: ...
+```
+
+## Canonical record contract (D05)
+
+Write to `submissions/<submission_id>.json` with required fields:
+
+- identity: `submission_id`, `github_pr_number`, `github_pr_url`
+- provenance:
+  - `source_repository_id`
+  - `source_repository_full_name`
+  - `github_pr_author_id`
+  - `github_pr_author_login`
+- state/timing:
+  - `status` (accepted)
+  - `eval_completed_at_utc`
+  - `evaluator_version`
+- HF pointers:
+  - `hf_repo`
+  - `hf_path`
+  - `hf_revision`
+- metrics:
+  - `overall_score`
+  - `shopping_score`, `reddit_score`, `gitlab_score`, `wikipedia_score`, `map_score`, `shopping_admin_score`
+  - `success_count`, `failure_count`, `error_count`, `missing_count`
+
+## End-to-end interactions
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant PR as Merged PR (leaderboard-submissions)
+    participant WF as Finalize Workflow
+    participant GH as GitHub API
+    participant FS as Branch Filesystem
+    participant EV as Evaluator
+    participant HF as Hugging Face
+    participant E as Rebuild Workflow (Lane E)
+
+    PR->>WF: pull_request.closed (merged=true)
+    WF->>WF: parse_finalize_event(GITHUB_EVENT_PATH)
+    WF->>GH: list_merged_pr_changed_files(repo, pr_number)
+    GH-->>WF: changed file paths
+    WF->>WF: resolve_single_intake_id(paths)
+    WF->>FS: load_intake_payload(submissions/inbox/<intake_id>/...)
+    WF->>EV: run_evaluation(intake payload)
+    EV-->>WF: score + counts + evaluator_version
+    WF->>HF: persist_payload_to_hf(submissions/<submission_id>/)
+    HF-->>WF: hf_revision
+    WF->>FS: write submissions/<submission_id>.json
+    WF->>FS: delete submissions/inbox/<intake_id>/
+    WF->>FS: commit + push to leaderboard-submissions
+    FS-->>E: push event on submissions/*.json
+    E->>E: rebuild leaderboard outputs (Lane E)
+```
+
+## File and component interactions
+
+```mermaid
+flowchart TD
+  A[.github/workflows/leaderboard-finalize.yml] --> B[inv dev.leaderboard.finalize]
+  B --> C[dev/leaderboard/finalize.py]
+  C --> D[src/webarena_verified/types/leaderboard/submission_record.py]
+  C --> E[submissions/inbox/<intake_id>/submission.json]
+  C --> F[submissions/inbox/<intake_id>/manifest.json]
+  C --> G[submissions/<submission_id>.json]
+  C --> H[HF repo: submissions/<submission_id>/]
+  G --> I[.github/workflows/leaderboard-rebuild.yml]
+```
+
+## Error handling policy
+
+- Fail closed on any of:
+  - missing/ambiguous intake folder
+  - event payload missing provenance fields
+  - HF upload failure
+  - canonical schema validation failure
+  - inbox delete failure
+- Do not write partial canonical state:
+  - if HF upload succeeds but canonical write fails, fail job and keep inbox untouched.
+  - if canonical write succeeds but inbox delete fails, fail job and keep record for manual reconciliation.
+- Emit actionable step summary with:
+  - `pr_number`, `submission_id`, `intake_id`, `hf_path`, `hf_revision`, error root cause.
+
+## Testing plan
+
+- Unit tests: `tests/leaderboard/test_finalize.py`
+  - event parsing
+  - `submission_id == pr_number`
+  - intake id extraction from changed files
+  - canonical record shape and required fields
+  - failure paths (no intake, multiple intake folders, HF failure)
+- Type tests: extend `tests/types/test_leaderboard_types.py`
+  - canonical record required provenance and score fields
+- Workflow smoke:
+  - merged PR fixture -> finalize writes canonical file + deletes inbox
+  - push on `submissions/*.json` triggers Lane E
+
+## Task checklist
 
 - [ ] D01 Implement finalize trigger (`deps: A04,C01`)
-  - Trigger on merged PR into `leaderboard-submissions`
-
 - [ ] D02 Canonical ID assignment (`deps: D01`)
-  - `submission_id = <pr_number>`
-
 - [ ] D03 Capture provenance fields from PR event (`deps: D01,B04`)
-  - source repository id/full name
-  - PR author id/login
-
 - [ ] D04 Upload canonical payload to HF (`deps: D02`)
-  - Destination `submissions/<submission_id>/`
-  - Capture HF revision
-
 - [ ] D05 Write canonical record (`deps: D02,D03,D04,B04`)
-  - Path `submissions/<submission_id>.json`
-
 - [ ] D06 Remove merged intake folder (`deps: D05`)
-  - Delete `submissions/inbox/<intake_id>/`
-
-- [ ] D07 Trigger rebuild workflow (`deps: D06`)
-  - Dispatch or trigger-by-change for rebuild
+- [ ] D07 Trigger rebuild workflow via push path (`deps: D06`)
 
 ## Outputs
 
 - Canonical records produced from merged intake PRs
-- Inbox cleaned after finalization
+- Inbox cleaned after successful finalization
+- Lane E triggered by push changes on `submissions/*.json`

--- a/dev/leaderboard/finalize.py
+++ b/dev/leaderboard/finalize.py
@@ -1,0 +1,454 @@
+"""Finalize merged leaderboard submission PRs into canonical records."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import shutil
+from typing import TYPE_CHECKING, Any
+from urllib import parse, request
+
+from huggingface_hub import HfApi
+from pydantic import BaseModel
+
+from webarena_verified.api import WebArenaVerified
+from webarena_verified.types.eval import WEBARENA_VERIFIED_VERSION, EvalStatus
+from webarena_verified.types.leaderboard import CanonicalSubmissionRecord
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_INTAKE_PREFIX = "submissions/inbox/"
+_TASKS_DIR_NAME = "tasks"
+_MISSING_SENTINEL_FILE = ".missing"
+_AGENT_RESPONSE_FILE = "agent_response.json"
+_NETWORK_HAR_FILE = "network.har"
+_SITE_KEYS = ("shopping", "reddit", "gitlab", "wikipedia", "map", "shopping_admin")
+_REQUIRED_SUBMISSION_FIELDS = (
+    "name",
+    "leaderboard",
+    "reference",
+    "created_at_utc",
+    "packaging_summary",
+)
+
+
+class FinalizeContext(BaseModel):
+    """Context extracted from a merged pull request event."""
+
+    pr_number: int
+    pr_url: str
+    merge_commit_sha: str
+    source_repository_id: int
+    source_repository_full_name: str
+    github_pr_author_id: int
+    github_pr_author_login: str
+
+
+class HFPersistResult(BaseModel):
+    """HF persistence result for one canonical submission payload upload."""
+
+    hf_repo: str
+    hf_path: str
+    hf_revision: str
+
+
+class FinalizeResult(BaseModel):
+    """Summary of finalize outputs."""
+
+    submission_id: int
+    intake_id: str
+    canonical_record_path: str
+    deleted_inbox_path: str
+    hf_repo: str
+    hf_path: str
+    hf_revision: str
+
+
+class FinalizeError(ValueError):
+    """Raised when finalize invariants are violated."""
+
+
+def _now_utc_z() -> str:
+    return dt.datetime.now(tz=dt.UTC).replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _require_dict(obj: Any, *, field_name: str) -> dict[str, Any]:
+    if not isinstance(obj, dict):
+        raise FinalizeError(f"{field_name} must be an object")
+    return obj
+
+
+def _require_int(obj: Any, *, field_name: str) -> int:
+    if isinstance(obj, bool) or not isinstance(obj, int):
+        raise FinalizeError(f"{field_name} must be an integer")
+    return obj
+
+
+def _require_non_empty_str(obj: Any, *, field_name: str) -> str:
+    if not isinstance(obj, str) or not obj.strip():
+        raise FinalizeError(f"{field_name} must be a non-empty string")
+    return obj
+
+
+def _http_get_json(url: str, token: str) -> Any:
+    req = request.Request(url)
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    with request.urlopen(req, timeout=60) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def parse_finalize_event(event_path: Path) -> FinalizeContext:
+    """Parse merged PR context from a GitHub event payload file."""
+    payload = _require_dict(json.loads(event_path.read_text(encoding="utf-8")), field_name="event payload")
+    pull_request = _require_dict(payload.get("pull_request"), field_name="pull_request")
+
+    merged = pull_request.get("merged")
+    if merged is not True:
+        raise FinalizeError("pull_request.merged must be true for finalize")
+
+    head = _require_dict(pull_request.get("head"), field_name="pull_request.head")
+    head_repo = _require_dict(head.get("repo"), field_name="pull_request.head.repo")
+    user = _require_dict(pull_request.get("user"), field_name="pull_request.user")
+
+    return FinalizeContext(
+        pr_number=_require_int(pull_request.get("number"), field_name="pull_request.number"),
+        pr_url=_require_non_empty_str(pull_request.get("html_url"), field_name="pull_request.html_url"),
+        merge_commit_sha=_require_non_empty_str(
+            pull_request.get("merge_commit_sha"),
+            field_name="pull_request.merge_commit_sha",
+        ),
+        source_repository_id=_require_int(head_repo.get("id"), field_name="pull_request.head.repo.id"),
+        source_repository_full_name=_require_non_empty_str(
+            head_repo.get("full_name"),
+            field_name="pull_request.head.repo.full_name",
+        ),
+        github_pr_author_id=_require_int(user.get("id"), field_name="pull_request.user.id"),
+        github_pr_author_login=_require_non_empty_str(
+            user.get("login"),
+            field_name="pull_request.user.login",
+        ),
+    )
+
+
+def list_merged_pr_changed_files(repo: str, pr_number: int, token: str) -> list[str]:
+    """List all changed file paths for one merged GitHub pull request."""
+    file_paths: list[str] = []
+    page = 1
+
+    repo_quoted = parse.quote(repo, safe="")
+    while True:
+        url = f"https://api.github.com/repos/{repo_quoted}/pulls/{pr_number}/files?per_page=100&page={page}"
+        payload = _http_get_json(url, token)
+        if not isinstance(payload, list):
+            raise FinalizeError(f"Unexpected GitHub file-list payload for PR #{pr_number}")
+
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            filename = item.get("filename")
+            if isinstance(filename, str):
+                file_paths.append(filename)
+
+        if len(payload) < 100:
+            break
+        page += 1
+
+    return file_paths
+
+
+def resolve_single_intake_id(changed_files: list[str]) -> str:
+    """Resolve exactly one intake folder ID from merged PR changed paths."""
+    intake_ids: set[str] = set()
+    for changed in changed_files:
+        if not changed.startswith(_INTAKE_PREFIX):
+            continue
+        suffix = changed[len(_INTAKE_PREFIX) :]
+        intake_id = suffix.split("/", maxsplit=1)[0]
+        if intake_id:
+            intake_ids.add(intake_id)
+
+    if not intake_ids:
+        raise FinalizeError("No intake folder changes found under submissions/inbox/<intake_id>/")
+    if len(intake_ids) != 1:
+        joined = ", ".join(sorted(intake_ids))
+        raise FinalizeError(f"Expected exactly one intake_id, found: {joined}")
+    return next(iter(intake_ids))
+
+
+def _load_json_file(path: Path, *, field_name: str) -> dict[str, Any]:
+    if not path.exists():
+        raise FinalizeError(f"{field_name} file is missing: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return _require_dict(payload, field_name=field_name)
+
+
+def load_intake_payload(repo_root: Path, intake_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Load intake submission and manifest payloads for one intake folder."""
+    intake_root = repo_root / _INTAKE_PREFIX / intake_id
+    submission = _load_json_file(intake_root / "submission.json", field_name="submission")
+    manifest = _load_json_file(intake_root / "manifest.json", field_name="manifest")
+    return submission, manifest
+
+
+def _validate_intake_submission(submission: dict[str, Any]) -> None:
+    missing = [field for field in _REQUIRED_SUBMISSION_FIELDS if field not in submission]
+    if missing:
+        joined = ", ".join(missing)
+        raise FinalizeError(f"submission.json is missing required field(s): {joined}")
+
+    leaderboard = submission.get("leaderboard")
+    if leaderboard not in {"hard", "full", "both"}:
+        raise FinalizeError("submission.json field 'leaderboard' must be one of: hard, full, both")
+
+
+def _task_id_from_path(task_dir: Path) -> int:
+    if not task_dir.name.isdigit():
+        raise FinalizeError(f"Task directory name must be numeric, got '{task_dir.name}'")
+    return int(task_dir.name)
+
+
+def _task_sites(wa: WebArenaVerified, task_id: int) -> list[str]:
+    task = wa.get_task(task_id)
+    return [str(site.value) for site in task.sites if str(site.value) in _SITE_KEYS]
+
+
+def _evaluate_task_status(wa: WebArenaVerified, *, task_id: int, task_dir: Path) -> str:
+    if (task_dir / _MISSING_SENTINEL_FILE).exists():
+        return "missing"
+
+    agent_response = task_dir / _AGENT_RESPONSE_FILE
+    network_har = task_dir / _NETWORK_HAR_FILE
+    if not agent_response.exists() or not network_har.exists():
+        raise FinalizeError(
+            f"Task {task_id} must include {_AGENT_RESPONSE_FILE} and {_NETWORK_HAR_FILE} or use .missing sentinel"
+        )
+
+    result = wa.evaluate_task(task_id=task_id, agent_response=agent_response, network_trace=network_har)
+    if result.status == EvalStatus.SUCCESS:
+        return "success"
+    if result.status == EvalStatus.ERROR:
+        return "error"
+    return "failure"
+
+
+def _site_scores(*, site_total: dict[str, int], site_success: dict[str, int]) -> dict[str, float]:
+    scores: dict[str, float] = {}
+    for site in _SITE_KEYS:
+        total = site_total[site]
+        scores[site] = 0.0 if total == 0 else site_success[site] / total
+    return scores
+
+
+def run_evaluation(repo_root: Path, intake_id: str, evaluator_version: str) -> dict[str, Any]:
+    """Evaluate intake task payloads and return leaderboard metric fields."""
+    tasks_root = repo_root / _INTAKE_PREFIX / intake_id / _TASKS_DIR_NAME
+    if not tasks_root.exists():
+        raise FinalizeError(f"Missing intake tasks directory: {tasks_root}")
+
+    wa = WebArenaVerified()
+    success_count = 0
+    failure_count = 0
+    error_count = 0
+    missing_count = 0
+
+    site_total: dict[str, int] = dict.fromkeys(_SITE_KEYS, 0)
+    site_success: dict[str, int] = dict.fromkeys(_SITE_KEYS, 0)
+
+    task_dirs = sorted(path for path in tasks_root.iterdir() if path.is_dir())
+    if not task_dirs:
+        raise FinalizeError("No task directories found under submissions/inbox/<intake_id>/tasks/")
+
+    for task_dir in task_dirs:
+        task_id = _task_id_from_path(task_dir)
+        task_sites = _task_sites(wa, task_id)
+        for site in task_sites:
+            site_total[site] += 1
+
+        task_status = _evaluate_task_status(wa, task_id=task_id, task_dir=task_dir)
+        if task_status == "missing":
+            missing_count += 1
+            continue
+        if task_status == "success":
+            success_count += 1
+            for site in task_sites:
+                site_success[site] += 1
+            continue
+        if task_status == "error":
+            error_count += 1
+            continue
+        failure_count += 1
+
+    total_count = success_count + failure_count + error_count + missing_count
+    if total_count == 0:
+        raise FinalizeError("No tasks found for scoring")
+
+    site_scores = _site_scores(site_total=site_total, site_success=site_success)
+
+    resolved_version = evaluator_version or WEBARENA_VERIFIED_VERSION
+    return {
+        "overall_score": success_count / total_count,
+        "shopping_score": site_scores["shopping"],
+        "reddit_score": site_scores["reddit"],
+        "gitlab_score": site_scores["gitlab"],
+        "wikipedia_score": site_scores["wikipedia"],
+        "map_score": site_scores["map"],
+        "shopping_admin_score": site_scores["shopping_admin"],
+        "success_count": success_count,
+        "failure_count": failure_count,
+        "error_count": error_count,
+        "missing_count": missing_count,
+        "webarena_verified_version": resolved_version,
+    }
+
+
+def persist_payload_to_hf(
+    *,
+    repo_root: Path,
+    intake_id: str,
+    submission_id: int,
+    hf_repo: str,
+    hf_token: str,
+) -> HFPersistResult:
+    """Upload merged intake payload to canonical HF path and capture revision."""
+    intake_root = repo_root / _INTAKE_PREFIX / intake_id
+    if not intake_root.exists():
+        raise FinalizeError(f"Intake path does not exist: {intake_root}")
+
+    hf_path = f"submissions/{submission_id}"
+    commit_info = HfApi(token=hf_token or None).upload_folder(
+        repo_id=hf_repo,
+        repo_type="dataset",
+        folder_path=str(intake_root),
+        path_in_repo=hf_path,
+        commit_message=f"Finalize leaderboard submission {submission_id}",
+    )
+    hf_revision = getattr(commit_info, "oid", "")
+    if not isinstance(hf_revision, str) or not hf_revision:
+        raise FinalizeError("Unable to capture HF revision from upload result")
+
+    return HFPersistResult(hf_repo=hf_repo, hf_path=hf_path, hf_revision=hf_revision)
+
+
+def _manifest_checksum(manifest: dict[str, Any]) -> str:
+    payload = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def build_canonical_record(
+    *,
+    context: FinalizeContext,
+    submission_id: int,
+    intake_submission: dict[str, Any],
+    intake_manifest: dict[str, Any],
+    eval_summary: dict[str, Any],
+    hf_result: HFPersistResult,
+    now_utc: str,
+) -> dict[str, Any]:
+    """Build canonical accepted record payload and validate it."""
+    _validate_intake_submission(intake_submission)
+
+    payload = {
+        "submission_id": submission_id,
+        "github_pr_number": context.pr_number,
+        "github_pr_url": context.pr_url,
+        "source_repository_id": context.source_repository_id,
+        "source_repository_full_name": context.source_repository_full_name,
+        "github_pr_author_id": context.github_pr_author_id,
+        "github_pr_author_login": context.github_pr_author_login,
+        "eval_completed_at_utc": now_utc,
+        "webarena_verified_version": eval_summary["webarena_verified_version"],
+        "huggingface_dataset_repo": f"{hf_result.hf_repo}/{hf_result.hf_path}",
+        "huggingface_dataset_revision": hf_result.hf_revision,
+        "name": intake_submission["name"],
+        "leaderboard": intake_submission["leaderboard"],
+        "reference": intake_submission["reference"],
+        "model_version": intake_submission.get("version"),
+        "contact_info": intake_submission.get("contact_info"),
+        "overall_score": eval_summary["overall_score"],
+        "shopping_score": eval_summary["shopping_score"],
+        "reddit_score": eval_summary["reddit_score"],
+        "gitlab_score": eval_summary["gitlab_score"],
+        "wikipedia_score": eval_summary["wikipedia_score"],
+        "map_score": eval_summary["map_score"],
+        "shopping_admin_score": eval_summary["shopping_admin_score"],
+        "success_count": eval_summary["success_count"],
+        "failure_count": eval_summary["failure_count"],
+        "error_count": eval_summary["error_count"],
+        "missing_count": eval_summary["missing_count"],
+        "checksum": _manifest_checksum(intake_manifest),
+    }
+    validated = CanonicalSubmissionRecord.model_validate(payload)
+    return validated.model_dump(mode="python")
+
+
+def write_canonical_record(*, repo_root: Path, submission_id: int, record: dict[str, Any]) -> Path:
+    """Write canonical submission record JSON to submissions/<submission_id>.json."""
+    output_path = repo_root / "submissions" / f"{submission_id}.json"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    validated = CanonicalSubmissionRecord.model_validate(record)
+    output_path.write_text(validated.model_dump_json(indent=2) + "\n", encoding="utf-8")
+    return output_path
+
+
+def delete_inbox_folder(*, repo_root: Path, intake_id: str) -> Path:
+    """Delete the merged intake folder after canonicalization completes."""
+    inbox_path = repo_root / _INTAKE_PREFIX / intake_id
+    if not inbox_path.exists():
+        raise FinalizeError(f"Inbox path does not exist: {inbox_path}")
+    shutil.rmtree(inbox_path)
+    return inbox_path
+
+
+def finalize_submission(
+    *,
+    repo_root: Path,
+    event_path: Path,
+    github_repo: str,
+    github_token: str,
+    hf_repo: str,
+    hf_token: str,
+    evaluator_version: str,
+) -> FinalizeResult:
+    """Finalize a merged intake PR into canonical record + HF snapshot."""
+    context = parse_finalize_event(event_path)
+    submission_id = context.pr_number
+
+    changed_files = list_merged_pr_changed_files(github_repo, context.pr_number, github_token)
+    intake_id = resolve_single_intake_id(changed_files)
+
+    intake_submission, intake_manifest = load_intake_payload(repo_root, intake_id)
+    eval_summary = run_evaluation(repo_root, intake_id, evaluator_version)
+    hf_result = persist_payload_to_hf(
+        repo_root=repo_root,
+        intake_id=intake_id,
+        submission_id=submission_id,
+        hf_repo=hf_repo,
+        hf_token=hf_token,
+    )
+
+    canonical_record = build_canonical_record(
+        context=context,
+        submission_id=submission_id,
+        intake_submission=intake_submission,
+        intake_manifest=intake_manifest,
+        eval_summary=eval_summary,
+        hf_result=hf_result,
+        now_utc=_now_utc_z(),
+    )
+    record_path = write_canonical_record(repo_root=repo_root, submission_id=submission_id, record=canonical_record)
+    inbox_path = delete_inbox_folder(repo_root=repo_root, intake_id=intake_id)
+
+    return FinalizeResult(
+        submission_id=submission_id,
+        intake_id=intake_id,
+        canonical_record_path=str(record_path),
+        deleted_inbox_path=str(inbox_path),
+        hf_repo=hf_result.hf_repo,
+        hf_path=hf_result.hf_path,
+        hf_revision=hf_result.hf_revision,
+    )

--- a/dev/leaderboard/tasks.py
+++ b/dev/leaderboard/tasks.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import os
 import logging
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -12,6 +12,7 @@ from huggingface_hub import HfApi
 from invoke import task
 
 from dev.leaderboard import constants
+from dev.leaderboard.finalize import finalize_submission
 from dev.leaderboard.hf_discussion_client import HFDiscussionClient
 from dev.leaderboard.hf_submission_validator import HFSubmissionValidator
 from dev.leaderboard.pr_gate_intake_validator import PRGateValidationError, run_pr_gate_intake_validation
@@ -50,6 +51,29 @@ def _parse_bool(value: str | bool) -> bool:
     if isinstance(value, bool):
         return value
     return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@task(name="finalize")
+def finalize(
+    _ctx,
+    event_path: str,
+    github_repo: str,
+    hf_repo: str,
+    github_token: str = "",
+    hf_token: str = "",
+    evaluator_version: str = "",
+) -> None:
+    """Finalize one merged intake PR into a canonical submission record."""
+    result = finalize_submission(
+        repo_root=Path.cwd(),
+        event_path=Path(event_path),
+        github_repo=github_repo,
+        github_token=github_token,
+        hf_repo=hf_repo,
+        hf_token=hf_token,
+        evaluator_version=evaluator_version,
+    )
+    print(result.model_dump_json(indent=2))
 
 
 @task(name="hf-handle-pr")

--- a/src/webarena_verified/types/leaderboard/submission_record.py
+++ b/src/webarena_verified/types/leaderboard/submission_record.py
@@ -2,7 +2,6 @@
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from .submission_payload import SubmissionLeaderboard
 from ._validators import (
     validate_checksum,
     validate_email,
@@ -10,6 +9,7 @@ from ._validators import (
     validate_model_name,
     validate_reference_url,
 )
+from .submission_payload import SubmissionLeaderboard
 
 
 class CanonicalSubmissionRecord(BaseModel):

--- a/tests/leaderboard/test_finalize.py
+++ b/tests/leaderboard/test_finalize.py
@@ -1,0 +1,135 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from dev.leaderboard import finalize
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _merged_pr_event() -> dict:
+    return {
+        "pull_request": {
+            "merged": True,
+            "number": 42,
+            "html_url": "https://github.com/org/repo/pull/42",
+            "merge_commit_sha": "abc123",
+            "head": {"repo": {"id": 999, "full_name": "fork-owner/repo"}},
+            "user": {"id": 77, "login": "alice"},
+        }
+    }
+
+
+def test_parse_finalize_event_extracts_required_fields(tmp_path: Path):
+    event_path = tmp_path / "event.json"
+    _write_json(event_path, _merged_pr_event())
+
+    parsed = finalize.parse_finalize_event(event_path)
+
+    assert parsed.pr_number == 42
+    assert parsed.pr_url.endswith("/pull/42")
+    assert parsed.source_repository_full_name == "fork-owner/repo"
+    assert parsed.github_pr_author_login == "alice"
+
+
+def test_resolve_single_intake_id_requires_exactly_one():
+    changed = [
+        "submissions/inbox/intake-1/submission.json",
+        "submissions/inbox/intake-1/manifest.json",
+    ]
+    assert finalize.resolve_single_intake_id(changed) == "intake-1"
+
+    with pytest.raises(finalize.FinalizeError, match="Expected exactly one intake_id"):
+        finalize.resolve_single_intake_id(
+            [
+                "submissions/inbox/intake-1/submission.json",
+                "submissions/inbox/intake-2/submission.json",
+            ]
+        )
+
+
+def test_finalize_submission_writes_canonical_record_and_deletes_inbox(tmp_path: Path, monkeypatch):
+    repo_root = tmp_path
+    event_path = repo_root / "event.json"
+    _write_json(event_path, _merged_pr_event())
+
+    intake_root = repo_root / "submissions" / "inbox" / "intake-123"
+    _write_json(
+        intake_root / "submission.json",
+        {
+            "name": "TeamX/ModelY",
+            "leaderboard": "both",
+            "reference": "https://example.com/paper",
+            "created_at_utc": "2026-03-07T10:00:00Z",
+            "packaging_summary": {"tasks_packaged": 2},
+        },
+    )
+    _write_json(
+        intake_root / "manifest.json",
+        {
+            "schema_version": "1.0",
+            "created_at_utc": "2026-03-07T10:00:00Z",
+            "files": [],
+        },
+    )
+
+    monkeypatch.setattr(
+        finalize,
+        "list_merged_pr_changed_files",
+        lambda repo, pr_number, token: [
+            "submissions/inbox/intake-123/submission.json",
+            "submissions/inbox/intake-123/manifest.json",
+        ],
+    )
+    monkeypatch.setattr(
+        finalize,
+        "run_evaluation",
+        lambda repo_root, intake_id, evaluator_version: {
+            "overall_score": 0.5,
+            "shopping_score": 1.0,
+            "reddit_score": 0.0,
+            "gitlab_score": 0.0,
+            "wikipedia_score": 0.0,
+            "map_score": 0.0,
+            "shopping_admin_score": 1.0,
+            "success_count": 1,
+            "failure_count": 1,
+            "error_count": 0,
+            "missing_count": 0,
+            "webarena_verified_version": "1.2.3",
+        },
+    )
+    monkeypatch.setattr(
+        finalize,
+        "persist_payload_to_hf",
+        lambda **kwargs: finalize.HFPersistResult(
+            hf_repo=kwargs["hf_repo"],
+            hf_path=f"submissions/{kwargs['submission_id']}",
+            hf_revision="hf-rev-1",
+        ),
+    )
+    monkeypatch.setattr(finalize, "_now_utc_z", lambda: "2026-03-07T12:00:00Z")
+
+    result = finalize.finalize_submission(
+        repo_root=repo_root,
+        event_path=event_path,
+        github_repo="org/repo",
+        github_token="gh",
+        hf_repo="org/hf",
+        hf_token="hf",
+        evaluator_version="",
+    )
+
+    canonical_path = repo_root / "submissions" / "42.json"
+    assert result.submission_id == 42
+    assert canonical_path.exists()
+    assert not intake_root.exists()
+
+    canonical_payload = json.loads(canonical_path.read_text(encoding="utf-8"))
+    assert canonical_payload["github_pr_number"] == 42
+    assert canonical_payload["huggingface_dataset_revision"] == "hf-rev-1"
+    assert canonical_payload["submission_id"] == 42

--- a/tests/types/test_leaderboard_types.py
+++ b/tests/types/test_leaderboard_types.py
@@ -237,5 +237,5 @@ def test_intake_manifest_rejects_duplicate_paths(intake_manifest_payload: dict):
 def test_intake_manifest_rejects_path_traversal(intake_manifest_payload: dict):
     intake_manifest_payload["files"][0]["path"] = "../submission.json"
 
-    with pytest.raises(ValidationError, match="must not contain '..'"):
+    with pytest.raises(ValidationError, match=r"must not contain '\.\.'"):
         IntakeManifest(**intake_manifest_payload)


### PR DESCRIPTION
## Summary
- add a merged-PR finalize workflow for `leaderboard-submissions` that canonicalizes intake payloads, uploads canonical snapshots to HF, writes `submissions/<submission_id>.json`, and removes inbox folders
- introduce a canonical submission record type plus finalize task wiring in leaderboard invoke tasks, and document Lane D implementation details with workflow/code interactions
- add unit/type coverage for finalize event parsing, intake resolution, canonical record validation, and end-to-end finalize write/delete behavior

## Validation
- `uv run ruff check dev/leaderboard/finalize.py dev/leaderboard/tasks.py src/webarena_verified/types/leaderboard/submission_record.py tests/leaderboard/test_finalize.py tests/types/test_leaderboard_types.py`
- `uv run pytest tests/leaderboard/test_finalize.py tests/types/test_leaderboard_types.py`
- `uv run inv --list dev.leaderboard`