### PR TITLE
Add read-only PR gate intake validation

### DIFF
--- a/.github/workflows/leaderboard-pr-gate.yml
+++ b/.github/workflows/leaderboard-pr-gate.yml
@@ -23,6 +23,8 @@ jobs:
   pr-gate:
     name: Leaderboard PR Gate
     runs-on: ubuntu-latest
+    env:
+      LEADERBOARD_EVALUATOR_VERSION: "1.2.3"
     steps:
       - name: Checkout PR head (read-only)
         uses: actions/checkout@v4
@@ -35,14 +37,50 @@ jobs:
         with:
           sync-args: --group dev
 
-      - name: Validate intake contract and invariants
+      - name: Validate intake contract, invariants, and score preview
+        id: gate
+        continue-on-error: true
         run: |
           set -euo pipefail
-          uv run inv dev.leaderboard.pr-gate-intake-validate \
+
+          set +e
+          GATE_OUTPUT="$(uv run inv dev.leaderboard.pr-gate-intake-validate \
             --base-sha "${{ github.event.pull_request.base.sha }}" \
-            --head-sha "${{ github.event.pull_request.head.sha }}"
+            --head-sha "${{ github.event.pull_request.head.sha }}" 2>&1)"
+          GATE_EXIT=$?
+          set -e
+
+          printf '%s\n' "$GATE_OUTPUT"
+
+          echo "gate_exit_code=$GATE_EXIT" >> "$GITHUB_OUTPUT"
+          {
+            echo "gate_output<<EOF"
+            printf '%s\n' "$GATE_OUTPUT"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$GATE_EXIT" -eq 0 ]; then
+            INTAKE_ID="$(printf '%s\n' "$GATE_OUTPUT" | sed -n 's/^intake_id=//p' | tail -n 1)"
+            CHANGED_FILES="$(printf '%s\n' "$GATE_OUTPUT" | sed -n 's/^changed_files=//p' | tail -n 1)"
+            EVALUATOR_VERSION="$(printf '%s\n' "$GATE_OUTPUT" | sed -n 's/^evaluator_version=//p' | tail -n 1)"
+            OVERALL_SCORE="$(printf '%s\n' "$GATE_OUTPUT" | sed -n 's/^overall_score=//p' | tail -n 1)"
+            SUCCESS_COUNT="$(printf '%s\n' "$GATE_OUTPUT" | sed -n 's/^success_count=//p' | tail -n 1)"
+            FAILURE_COUNT="$(printf '%s\n' "$GATE_OUTPUT" | sed -n 's/^failure_count=//p' | tail -n 1)"
+            ERROR_COUNT="$(printf '%s\n' "$GATE_OUTPUT" | sed -n 's/^error_count=//p' | tail -n 1)"
+            MISSING_COUNT="$(printf '%s\n' "$GATE_OUTPUT" | sed -n 's/^missing_count=//p' | tail -n 1)"
+
+            echo "intake_id=$INTAKE_ID" >> "$GITHUB_OUTPUT"
+            echo "changed_files=$CHANGED_FILES" >> "$GITHUB_OUTPUT"
+            echo "evaluator_version=$EVALUATOR_VERSION" >> "$GITHUB_OUTPUT"
+            echo "overall_score=$OVERALL_SCORE" >> "$GITHUB_OUTPUT"
+            echo "success_count=$SUCCESS_COUNT" >> "$GITHUB_OUTPUT"
+            echo "failure_count=$FAILURE_COUNT" >> "$GITHUB_OUTPUT"
+            echo "error_count=$ERROR_COUNT" >> "$GITHUB_OUTPUT"
+            echo "missing_count=$MISSING_COUNT" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Publish gate summary
+        if: always()
         run: |
           {
             echo "## Leaderboard PR Gate"
@@ -50,5 +88,33 @@ jobs:
             echo "- Trigger: pull_request on \\`leaderboard-submissions\\` with path filter \\`submissions/inbox/**\\`."
             echo "- Permissions: \\`contents: read\\` only."
             echo "- Checkout credentials persistence: \\`false\\` (no push token)."
-            echo "- C03-C05 gate checks: single intake folder, required files, manifest integrity, and task invariants."
+            echo "- Evaluator version pin (prefix): \\`${LEADERBOARD_EVALUATOR_VERSION}\\`."
+            if [ "${{ steps.gate.outputs.gate_exit_code }}" = "0" ]; then
+              echo ""
+              echo "### Score Preview"
+              echo "- Intake ID: \\`${{ steps.gate.outputs.intake_id }}\\`"
+              echo "- Changed files: \\`${{ steps.gate.outputs.changed_files }}\\`"
+              echo "- Evaluator version: \\`${{ steps.gate.outputs.evaluator_version }}\\`"
+              echo "- Overall score: \\`${{ steps.gate.outputs.overall_score }}\\`"
+              echo "- success_count: \\`${{ steps.gate.outputs.success_count }}\\`"
+              echo "- failure_count: \\`${{ steps.gate.outputs.failure_count }}\\`"
+              echo "- error_count: \\`${{ steps.gate.outputs.error_count }}\\`"
+              echo "- missing_count: \\`${{ steps.gate.outputs.missing_count }}\\`"
+            else
+              echo ""
+              echo "### Validation Failure"
+              echo "- Gate exited with code: \\`${{ steps.gate.outputs.gate_exit_code }}\\`"
+              echo ""
+              echo "```text"
+              printf '%s\n' "${{ steps.gate.outputs.gate_output }}"
+              echo "```"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Enforce gate result
+        if: always()
+        run: |
+          if [ "${{ steps.gate.outputs.gate_exit_code }}" != "0" ]; then
+            echo "PR Gate failed"
+            exit 1
+          fi

--- a/.github/workflows/leaderboard-pr-gate.yml
+++ b/.github/workflows/leaderboard-pr-gate.yml
@@ -1,0 +1,54 @@
+name: Leaderboard PR Gate
+
+on:
+  pull_request:
+    branches:
+      - leaderboard-submissions
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    paths:
+      - "submissions/inbox/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: leaderboard-pr-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-gate:
+    name: Leaderboard PR Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head (read-only)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup environment
+        uses: ./.github/actions/setup
+        with:
+          sync-args: --group dev
+
+      - name: Validate intake contract and invariants
+        run: |
+          set -euo pipefail
+          uv run inv dev.leaderboard.pr-gate-intake-validate \
+            --base-sha "${{ github.event.pull_request.base.sha }}" \
+            --head-sha "${{ github.event.pull_request.head.sha }}"
+
+      - name: Publish gate summary
+        run: |
+          {
+            echo "## Leaderboard PR Gate"
+            echo ""
+            echo "- Trigger: pull_request on \\`leaderboard-submissions\\` with path filter \\`submissions/inbox/**\\`."
+            echo "- Permissions: \\`contents: read\\` only."
+            echo "- Checkout credentials persistence: \\`false\\` (no push token)."
+            echo "- C03-C05 gate checks: single intake folder, required files, manifest integrity, and task invariants."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.wip/lane-c-pr-gate-implementation-plan.md
+++ b/.wip/lane-c-pr-gate-implementation-plan.md
@@ -1,0 +1,381 @@
+# Lane C PR Gate Implementation Plan (Code-Level)
+
+This is the executable design for Lane C (`.wip/lane-c-pr-gate.md`) using the approved architecture in `.wip/leaderboard-alignment-plan.md`.
+
+## Scope
+
+- Trigger on PRs to `leaderboard-submissions` that touch `submissions/inbox/**`.
+- Enforce read-only execution boundaries.
+- Validate intake structure + manifest integrity + task invariants.
+- Compute deterministic score preview using pinned evaluator version.
+- Publish clear diagnostics in check summary (and optional PR comment).
+
+## Non-goals
+
+- No canonical record writes (`submissions/<submission_id>.json`).
+- No leaderboard file writes.
+- No Hugging Face writes.
+- No branch mutation.
+
+## Proposed files and signatures
+
+### 1) New workflow
+
+` .github/workflows/leaderboard-pr-gate.yml `
+
+```yaml
+name: Leaderboard PR Gate
+
+on:
+  pull_request:
+    branches: [leaderboard-submissions]
+    paths:
+      - "submissions/inbox/**"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  pr-gate:
+    name: Leaderboard PR Gate
+    runs-on: ubuntu-latest
+```
+
+Notes:
+- Keep job name stable for required-check policy (Lane A / A04).
+- `pull-requests: write` is only for comment updates; if comments are removed, downgrade to read-only.
+
+### 2) Intake contract models (Lane B consumption)
+
+`src/webarena_verified/types/leaderboard/intake_payload.py`
+
+```python
+from enum import StrEnum
+
+from pydantic import BaseModel, Field, ConfigDict
+
+
+class IntakeLeaderboard(StrEnum):
+    HARD = "hard"
+    FULL = "full"
+    BOTH = "both"
+
+class IntakeSubmission(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    name: str = Field(min_length=1)
+    leaderboard: IntakeLeaderboard
+    reference: str = Field(min_length=1)
+    created_at_utc: str
+    packaging_summary: dict
+    version: str | None = None
+    contact_info: str | None = None
+
+class IntakeManifestFile(BaseModel):
+    path: str = Field(min_length=1)
+    sha256: str
+    size_bytes: int = Field(ge=0)
+
+class IntakeManifest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    created_at_utc: str
+    schema_version: str
+    files: list[IntakeManifestFile]
+```
+
+### 3) PR Gate runtime models
+
+`dev/leaderboard/pr_gate/models.py`
+
+```python
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PRGateContext(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    repo_root: Path
+    base_sha: str
+    head_sha: str
+    pr_number: int
+    pr_url: str
+    actor: str
+    summary_path: Path | None
+    github_output_path: Path | None
+
+
+class IntakeSelection(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    intake_id: str
+    intake_root: Path
+    changed_paths: list[str]
+
+
+class ValidationIssue(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    code: str
+    path: str
+    message: str
+    hint: str | None = None
+
+
+class ScorePreview(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    evaluator_version: str
+    overall_score: float
+    success_count: int
+    failure_count: int
+    error_count: int
+    missing_count: int
+
+
+class PRGateResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    intake: IntakeSelection
+    issues: list[ValidationIssue]
+    score_preview: ScorePreview | None
+```
+
+### 4) Diff + intake selection
+
+`dev/leaderboard/pr_gate/diff_selection.py`
+
+```python
+from pathlib import Path
+
+def list_changed_paths(base_sha: str, head_sha: str, repo_root: Path) -> list[str]: ...
+
+def select_single_intake(changed_paths: list[str], inbox_prefix: str = "submissions/inbox/") -> IntakeSelection: ...
+```
+
+Responsibilities:
+- Build changed path set from git diff.
+- Enforce "exactly one intake folder per PR".
+- Reject paths outside `submissions/inbox/<intake_id>/**`.
+
+### 5) Validators
+
+`dev/leaderboard/pr_gate/validators.py`
+
+```python
+from pathlib import Path
+
+def validate_required_layout(intake_root: Path) -> list[ValidationIssue]: ...
+def validate_submission_schema(submission_file: Path) -> list[ValidationIssue]: ...
+def validate_manifest_schema(manifest_file: Path) -> list[ValidationIssue]: ...
+def validate_manifest_integrity(intake_root: Path, manifest_file: Path) -> list[ValidationIssue]: ...
+def validate_task_invariants(tasks_root: Path) -> list[ValidationIssue]: ...
+```
+
+Rules:
+- Required files: `submission.json`, `manifest.json`, `tasks/**`.
+- Manifest checks: recompute `sha256` and `size_bytes` for each declared file.
+- Path safety: block absolute paths and traversal (`..`) from manifest entries.
+- Task XOR: `.missing` xor (`agent_response.json` + `network.har`) per task directory.
+
+### 6) Score preview adapter
+
+`dev/leaderboard/pr_gate/scoring.py`
+
+```python
+from pathlib import Path
+
+def compute_score_preview(
+    intake_root: Path,
+    evaluator_version: str,
+    *,
+    timeout_seconds: int = 900,
+) -> ScorePreview: ...
+```
+
+Behavior:
+- Uses pinned evaluator version from workflow env (`LEADERBOARD_EVALUATOR_VERSION`).
+- Deterministic task ordering (numeric ascending task id).
+- Returns summary only (no canonical writes).
+- Raises a typed gate error if scoring toolchain fails.
+
+### 7) Reporting
+
+`dev/leaderboard/pr_gate/reporting.py`
+
+```python
+def render_summary_markdown(result: PRGateResult) -> str: ...
+def render_failure_comment(result: PRGateResult) -> str: ...
+def write_step_summary(markdown: str, summary_path: str | None) -> None: ...
+def write_github_outputs(result: PRGateResult, github_output_path: str | None) -> None: ...
+```
+
+Output contract:
+- `gate_status=pass|fail`
+- `issue_count=<int>`
+- `intake_id=<str>`
+- `score_preview_json=<json>` (when available)
+
+### 8) Orchestration entrypoint
+
+`dev/leaderboard/pr_gate/run.py`
+
+```python
+def run_pr_gate(context: PRGateContext) -> int: ...
+```
+
+Execution order:
+1. changed-path selection
+2. structure/schema/integrity/task validations
+3. score preview (only if validations pass)
+4. summary + outputs write
+5. exit code (`0` pass, `1` fail)
+
+### 9) Invoke task wiring
+
+`dev/leaderboard_tasks.py`
+
+```python
+@task(name="pr-gate")
+def pr_gate(
+    _ctx,
+    base_sha: str,
+    head_sha: str,
+    pr_number: int,
+    pr_url: str = "",
+    actor: str = "",
+    summary_path: str = "",
+    github_output_path: str = "",
+) -> None: ...
+```
+
+## Interaction diagram (modules)
+
+```mermaid
+flowchart LR
+  WF[GitHub Workflow\nleaderboard-pr-gate.yml] --> INV[Invoke task\ndev.leaderboard.pr-gate]
+  INV --> RUN[run_pr_gate(context)]
+
+  RUN --> DIFF[list_changed_paths + select_single_intake]
+  RUN --> VAL[validators.py]
+  RUN --> SCORE[scoring.py]
+  RUN --> REP[reporting.py]
+
+  VAL --> TYPES[src/.../intake_payload.py]
+  SCORE --> EVAL[webarena_verified evaluator\npinned version]
+
+  REP --> SUM[$GITHUB_STEP_SUMMARY]
+  REP --> OUT[$GITHUB_OUTPUT]
+  OUT --> CHECK[Required check result]
+```
+
+## Runtime sequence (single PR)
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant GH as GitHub pull_request
+  participant WF as PR Gate workflow
+  participant T as inv dev.leaderboard.pr-gate
+  participant V as validators
+  participant S as scorer
+  participant R as reporter
+
+  GH->>WF: PR opened/synchronized\n(paths: submissions/inbox/**)
+  WF->>T: base_sha, head_sha, pr_number, actor
+  T->>V: select intake + validate structure/schema/integrity/tasks
+  alt Validation issues exist
+    V-->>T: issues[]
+    T->>R: render fail summary/comment
+    R-->>WF: gate_status=fail, issue_count>0
+    WF-->>GH: required check FAILED
+  else Validation passed
+    V-->>T: issues=[]
+    T->>S: compute_score_preview(intake_root, evaluator_version)
+    S-->>T: score preview metrics
+    T->>R: render pass summary (+preview)
+    R-->>WF: gate_status=pass, score_preview_json
+    WF-->>GH: required check PASSED
+  end
+```
+
+## Failure taxonomy (for actionable diagnostics)
+
+- `C03_LAYOUT_MISSING_FILE`: missing `submission.json` / `manifest.json`.
+- `C03_LAYOUT_MULTIPLE_INTAKES`: PR modifies >1 intake folder.
+- `C04_MANIFEST_PATH_ESCAPE`: manifest path traverses outside intake root.
+- `C04_MANIFEST_HASH_MISMATCH`: sha256 mismatch on declared file.
+- `C04_MANIFEST_SIZE_MISMATCH`: size mismatch on declared file.
+- `C05_TASK_XOR_VIOLATION`: `.missing` and output files coexist or neither set.
+- `C06_SCORE_PREVIEW_ERROR`: scoring tool failure/timeouts/version mismatch.
+
+Every issue should include `code`, `path`, `message`, and `hint`.
+
+## Detailed rollout by Lane C tasks
+
+### C01 Trigger
+
+1. Add workflow with branch/path filters.
+2. Ensure check/job name is stable: `Leaderboard PR Gate`.
+3. Add concurrency for duplicate `synchronize` events:
+   - `group: pr-gate-${{ github.event.pull_request.number }}`
+   - `cancel-in-progress: true`
+
+### C02 Read-only enforcement
+
+1. Set least-privilege permissions.
+2. Checkout with `persist-credentials: false`.
+3. Block mutating commands in code review checklist (`git add/commit/push`, HF upload APIs).
+
+### C03-C05 Validations
+
+1. Implement selection + validators.
+2. Add deterministic issue ordering (sort by `path`, then `code`).
+3. Short-circuit scoring when `issues != []`.
+
+### C06 Score preview
+
+1. Pin evaluator version via workflow env.
+2. Use deterministic task traversal and fixed JSON serialization for output.
+3. Include preview metrics in summary table.
+
+### C07 Diagnostics
+
+1. Standard markdown template for pass/fail.
+2. One-line remediation hint per issue.
+3. Include intake id and PR number in heading for supportability.
+
+## Test plan
+
+### Unit tests
+
+`tests/leaderboard/test_pr_gate_selection.py`
+- no changed files -> fail
+- path outside inbox -> fail
+- two intake ids in one diff -> fail
+
+`tests/leaderboard/test_pr_gate_manifest.py`
+- valid manifest hash/size -> pass
+- hash mismatch -> deterministic fail code/path
+- path traversal entry -> fail
+
+`tests/leaderboard/test_pr_gate_tasks.py`
+- `.missing` only -> pass
+- pair (`agent_response.json`,`network.har`) only -> pass
+- both modes together -> fail
+- partial pair missing one file -> fail
+
+`tests/leaderboard/test_pr_gate_reporting.py`
+- summary includes issue table
+- outputs include `gate_status`, `issue_count`, `intake_id`
+
+### Workflow smoke tests
+
+- PR fixture with valid intake passes.
+- PR fixture with manifest mismatch fails and exposes path-specific message.
+- Check remains required-check compatible after reruns/synchronize events.
+
+## Acceptance criteria
+
+- C1: Only `submissions/inbox/<intake_id>/**` is accepted input scope.
+- C2: PR Gate never mutates repository or HF state.
+- C3: Manifest integrity checks are deterministic and path-safe.
+- C4: Task invariants enforce `.missing` xor outputs.
+- C5: Score preview is produced on valid payloads using pinned evaluator version.
+- C6: Failure output is actionable and path-specific.

--- a/.wip/lane-c-pr-gate.md
+++ b/.wip/lane-c-pr-gate.md
@@ -6,24 +6,29 @@ Validate intake payload and compute score preview without mutating branch state.
 
 ## Tasks
 
-- [ ] C01 Implement PR Gate trigger (`deps: A04,B01`)
+- [x] C01 Implement PR Gate trigger (`deps: A04,B01`)
   - `pull_request` on `leaderboard-submissions`
   - Path filters under `submissions/inbox/**`
+  - Implemented in `.github/workflows/leaderboard-pr-gate.yml`
 
-- [ ] C02 Enforce read-only execution (`deps: A05`)
+- [x] C02 Enforce read-only execution (`deps: A05`)
   - No branch writes
   - No HF writes
+  - Enforced via workflow permissions `contents: read` and checkout `persist-credentials: false`
 
-- [ ] C03 Validate intake structure (`deps: B01`)
+- [x] C03 Validate intake structure (`deps: B01`)
   - Exactly one intake folder per PR
   - Required files present
+  - Implemented in `dev/leaderboard/pr_gate_intake_validator.py`
 
-- [ ] C04 Validate manifest integrity (`deps: B03`)
+- [x] C04 Validate manifest integrity (`deps: B03`)
   - Recompute hash/size for declared files
   - Compare with `manifest.json`
+  - Implemented in `dev/leaderboard/pr_gate_intake_validator.py`
 
-- [ ] C05 Validate task invariants (`deps: B01`)
+- [x] C05 Validate task invariants (`deps: B01`)
   - `.missing` xor (`agent_response.json` + `network.har`)
+  - Implemented in `dev/leaderboard/pr_gate_intake_validator.py`
 
 - [ ] C06 Compute scoring preview (`deps: B05`)
   - Use pinned evaluator package version
@@ -36,3 +41,7 @@ Validate intake payload and compute score preview without mutating branch state.
 
 - PR Gate workflow ready and required-check compatible
 - Deterministic score preview in PR checks
+
+## Detailed implementation plan
+
+- See `.wip/lane-c-pr-gate-implementation-plan.md` for code-level signatures, module boundaries, interaction diagrams, and test matrix.

--- a/.wip/lane-c-pr-gate.md
+++ b/.wip/lane-c-pr-gate.md
@@ -30,12 +30,14 @@ Validate intake payload and compute score preview without mutating branch state.
   - `.missing` xor (`agent_response.json` + `network.har`)
   - Implemented in `dev/leaderboard/pr_gate_intake_validator.py`
 
-- [ ] C06 Compute scoring preview (`deps: B05`)
+- [x] C06 Compute scoring preview (`deps: B05`)
   - Use pinned evaluator package version
   - Emit result in check summary/comment
+  - Implemented via `dev/leaderboard/pr_gate_intake_validator.py` + `.github/workflows/leaderboard-pr-gate.yml`
 
-- [ ] C07 Improve failure diagnostics (`deps: C03,C04,C05,C06`)
+- [x] C07 Improve failure diagnostics (`deps: C03,C04,C05,C06`)
   - Actionable, path-specific errors
+  - Error codes/path-specific messages surfaced in validator output and gate summary
 
 ## Outputs
 

--- a/dev/leaderboard/pr_gate_intake_validator.py
+++ b/dev/leaderboard/pr_gate_intake_validator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+from importlib import metadata as importlib_metadata
 import json
 import subprocess
 from pathlib import Path
@@ -19,6 +20,10 @@ INBOX_PREFIX = "submissions/inbox/"
 
 class PRGateValidationError(Exception):
     """Raised when PR gate intake validation fails."""
+
+
+def _fail(code: str, message: str) -> None:
+    raise PRGateValidationError(f"[{code}] {message}")
 
 
 class IntakeSubmission(BaseModel):
@@ -93,6 +98,31 @@ class PRGateValidationResult(BaseModel):
     intake_id: str
     intake_root: Path
     changed_paths: list[str]
+    task_summary: "TaskInvariantSummary"
+    score_preview: "ScorePreview"
+
+
+class TaskInvariantSummary(BaseModel):
+    """Task-level invariant summary used by score preview."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    total_tasks: int = Field(ge=0)
+    artifact_tasks: int = Field(ge=0)
+    missing_tasks: int = Field(ge=0)
+
+
+class ScorePreview(BaseModel):
+    """Deterministic score preview emitted by PR gate."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    evaluator_version: str = Field(min_length=1)
+    overall_score: float
+    success_count: int = Field(ge=0)
+    failure_count: int = Field(ge=0)
+    error_count: int = Field(ge=0)
+    missing_count: int = Field(ge=0)
 
 
 def _run_git_diff_paths(base_sha: str, head_sha: str, repo_root: Path) -> list[str]:
@@ -103,24 +133,24 @@ def _run_git_diff_paths(base_sha: str, head_sha: str, repo_root: Path) -> list[s
 
 def _select_single_intake_id(changed_paths: list[str]) -> str:
     if not changed_paths:
-        raise PRGateValidationError("No files changed in PR diff")
+        _fail("C03_NO_DIFF", "No files changed in PR diff")
 
     invalid_scope = [path for path in changed_paths if not path.startswith(INBOX_PREFIX)]
     if invalid_scope:
         joined = ", ".join(sorted(invalid_scope))
-        raise PRGateValidationError(f"PR Gate accepts only intake paths under {INBOX_PREFIX}. Invalid paths: {joined}")
+        _fail("C03_SCOPE_INVALID", f"PR Gate accepts only intake paths under {INBOX_PREFIX}. Invalid paths: {joined}")
 
     intake_ids: set[str] = set()
     for path in changed_paths:
         suffix = path[len(INBOX_PREFIX) :]
         intake_id = suffix.split("/", maxsplit=1)[0].strip()
         if not intake_id:
-            raise PRGateValidationError(f"Invalid intake path: {path}")
+            _fail("C03_INTAKE_PATH_INVALID", f"Invalid intake path: {path}")
         intake_ids.add(intake_id)
 
     if len(intake_ids) != 1:
         joined = ", ".join(sorted(intake_ids))
-        raise PRGateValidationError(f"Exactly one intake folder is allowed per PR. Found: {joined}")
+        _fail("C03_MULTIPLE_INTAKES", f"Exactly one intake folder is allowed per PR. Found: {joined}")
 
     return next(iter(intake_ids))
 
@@ -129,23 +159,25 @@ def _read_json_file(path: Path) -> dict[str, Any]:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        raise PRGateValidationError(f"Invalid JSON at {path}: {exc}") from exc
+        raise PRGateValidationError(f"[C03_JSON_INVALID] Invalid JSON at {path}: {exc}") from exc
     if not isinstance(payload, dict):
-        raise PRGateValidationError(f"Expected JSON object at {path}")
+        _fail("C03_JSON_NOT_OBJECT", f"Expected JSON object at {path}")
     return payload
 
 
 def _resolve_declared_file(intake_root: Path, declared_path: str) -> Path:
     declared = Path(declared_path)
     if declared.is_absolute() or ".." in declared.parts:
-        raise PRGateValidationError(f"Manifest path is unsafe: {declared_path}")
+        _fail("C04_MANIFEST_PATH_UNSAFE", f"Manifest path is unsafe: {declared_path}")
 
     resolved = (intake_root / declared).resolve()
     intake_resolved = intake_root.resolve()
     try:
         resolved.relative_to(intake_resolved)
     except ValueError as exc:
-        raise PRGateValidationError(f"Manifest path escapes intake root: {declared_path}") from exc
+        raise PRGateValidationError(
+            f"[C04_MANIFEST_PATH_ESCAPE] Manifest path escapes intake root: {declared_path}"
+        ) from exc
     return resolved
 
 
@@ -157,17 +189,17 @@ def _sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def validate_intake_tree(intake_root: Path) -> tuple[IntakeSubmission, IntakeManifest]:
+def validate_intake_tree(intake_root: Path) -> tuple[IntakeSubmission, IntakeManifest, TaskInvariantSummary]:
     submission_file = intake_root / "submission.json"
     manifest_file = intake_root / "manifest.json"
     tasks_root = intake_root / "tasks"
 
     if not submission_file.is_file():
-        raise PRGateValidationError(f"Missing required file: {submission_file}")
+        _fail("C03_MISSING_REQUIRED_FILE", f"Missing required file: {submission_file}")
     if not manifest_file.is_file():
-        raise PRGateValidationError(f"Missing required file: {manifest_file}")
+        _fail("C03_MISSING_REQUIRED_FILE", f"Missing required file: {manifest_file}")
     if not tasks_root.is_dir():
-        raise PRGateValidationError(f"Missing required directory: {tasks_root}")
+        _fail("C03_MISSING_REQUIRED_DIR", f"Missing required directory: {tasks_root}")
 
     submission_payload = _read_json_file(submission_file)
     manifest_payload = _read_json_file(manifest_file)
@@ -175,52 +207,61 @@ def validate_intake_tree(intake_root: Path) -> tuple[IntakeSubmission, IntakeMan
     try:
         submission = IntakeSubmission.model_validate(submission_payload)
     except ValidationError as exc:
-        raise PRGateValidationError(f"Invalid submission schema in {submission_file}: {exc}") from exc
+        raise PRGateValidationError(
+            f"[C03_SUBMISSION_SCHEMA_INVALID] Invalid submission schema in {submission_file}: {exc}"
+        ) from exc
 
     try:
         manifest = IntakeManifest.model_validate(manifest_payload)
     except ValidationError as exc:
-        raise PRGateValidationError(f"Invalid manifest schema in {manifest_file}: {exc}") from exc
+        raise PRGateValidationError(
+            f"[C04_MANIFEST_SCHEMA_INVALID] Invalid manifest schema in {manifest_file}: {exc}"
+        ) from exc
 
     validate_manifest_integrity(intake_root, manifest)
-    validate_task_invariants(tasks_root)
-    return submission, manifest
+    task_summary = validate_task_invariants(tasks_root)
+    return submission, manifest, task_summary
 
 
 def validate_manifest_integrity(intake_root: Path, manifest: IntakeManifest) -> None:
     for entry in manifest.files:
         target = _resolve_declared_file(intake_root, entry.path)
         if not target.is_file():
-            raise PRGateValidationError(f"Manifest declared path does not exist as a file: {entry.path}")
+            _fail("C04_MANIFEST_PATH_MISSING", f"Manifest declared path does not exist as a file: {entry.path}")
 
         actual_size = target.stat().st_size
         if actual_size != entry.size_bytes:
-            raise PRGateValidationError(
-                f"Manifest size mismatch for {entry.path}: expected {entry.size_bytes}, got {actual_size}"
+            _fail(
+                "C04_MANIFEST_SIZE_MISMATCH",
+                f"Manifest size mismatch for {entry.path}: expected {entry.size_bytes}, got {actual_size}",
             )
 
         actual_sha = _sha256_file(target)
         if actual_sha != entry.sha256:
-            raise PRGateValidationError(
-                f"Manifest sha256 mismatch for {entry.path}: expected {entry.sha256}, got {actual_sha}"
+            _fail(
+                "C04_MANIFEST_SHA256_MISMATCH",
+                f"Manifest sha256 mismatch for {entry.path}: expected {entry.sha256}, got {actual_sha}",
             )
 
 
-def validate_task_invariants(tasks_root: Path) -> None:
+def validate_task_invariants(tasks_root: Path) -> TaskInvariantSummary:
     task_dirs = sorted([entry for entry in tasks_root.iterdir() if entry.is_dir()], key=lambda path: path.name)
     if not task_dirs:
-        raise PRGateValidationError(f"tasks directory must contain at least one task folder: {tasks_root}")
+        _fail("C05_TASKS_EMPTY", f"tasks directory must contain at least one task folder: {tasks_root}")
+
+    missing_tasks = 0
+    artifact_tasks = 0
 
     for task_dir in task_dirs:
         names = {entry.name for entry in task_dir.iterdir() if entry.is_file()}
         if not names:
-            raise PRGateValidationError(f"Task directory has no files: {task_dir}")
+            _fail("C05_TASK_EMPTY_DIR", f"Task directory has no files: {task_dir}")
 
         allowed = {TASK_MISSING_SENTINEL_FILE, TASK_AGENT_RESPONSE_FILE, TASK_NETWORK_HAR_FILE}
         extra = names - allowed
         if extra:
             joined = ", ".join(sorted(extra))
-            raise PRGateValidationError(f"Task directory has unsupported file(s) in {task_dir}: {joined}")
+            _fail("C05_TASK_UNSUPPORTED_FILE", f"Task directory has unsupported file(s) in {task_dir}: {joined}")
 
         has_missing = TASK_MISSING_SENTINEL_FILE in names
         has_agent = TASK_AGENT_RESPONSE_FILE in names
@@ -228,39 +269,103 @@ def validate_task_invariants(tasks_root: Path) -> None:
 
         if has_missing:
             if names != {TASK_MISSING_SENTINEL_FILE}:
-                raise PRGateValidationError(
-                    f"Task invariant failed in {task_dir}: {TASK_MISSING_SENTINEL_FILE} cannot coexist with other files"
+                _fail(
+                    "C05_TASK_XOR_VIOLATION",
+                    f"Task invariant failed in {task_dir}: {TASK_MISSING_SENTINEL_FILE} cannot coexist with other files",
                 )
             missing_file = task_dir / TASK_MISSING_SENTINEL_FILE
             if missing_file.stat().st_size != 0:
-                raise PRGateValidationError(
-                    f"Task invariant failed in {task_dir}: {TASK_MISSING_SENTINEL_FILE} must be empty"
+                _fail(
+                    "C05_TASK_MISSING_SENTINEL_NOT_EMPTY",
+                    f"Task invariant failed in {task_dir}: {TASK_MISSING_SENTINEL_FILE} must be empty",
                 )
+            missing_tasks += 1
             continue
 
         if not (has_agent and has_har):
-            raise PRGateValidationError(
+            _fail(
+                "C05_TASK_XOR_VIOLATION",
                 f"Task invariant failed in {task_dir}: expected {TASK_AGENT_RESPONSE_FILE} + {TASK_NETWORK_HAR_FILE} "
-                f"or only {TASK_MISSING_SENTINEL_FILE}"
+                f"or only {TASK_MISSING_SENTINEL_FILE}",
             )
 
         try:
             json.loads((task_dir / TASK_AGENT_RESPONSE_FILE).read_text(encoding="utf-8"))
         except json.JSONDecodeError as exc:
-            raise PRGateValidationError(f"Invalid JSON in {task_dir / TASK_AGENT_RESPONSE_FILE}: {exc}") from exc
+            raise PRGateValidationError(
+                f"[C05_TASK_AGENT_RESPONSE_INVALID_JSON] Invalid JSON in {task_dir / TASK_AGENT_RESPONSE_FILE}: {exc}"
+            ) from exc
 
         try:
             json.loads((task_dir / TASK_NETWORK_HAR_FILE).read_text(encoding="utf-8"))
         except json.JSONDecodeError as exc:
-            raise PRGateValidationError(f"Invalid JSON in {task_dir / TASK_NETWORK_HAR_FILE}: {exc}") from exc
+            raise PRGateValidationError(
+                f"[C05_TASK_NETWORK_HAR_INVALID_JSON] Invalid JSON in {task_dir / TASK_NETWORK_HAR_FILE}: {exc}"
+            ) from exc
+
+        artifact_tasks += 1
+
+    return TaskInvariantSummary(
+        total_tasks=len(task_dirs),
+        artifact_tasks=artifact_tasks,
+        missing_tasks=missing_tasks,
+    )
 
 
-def run_pr_gate_intake_validation(repo_root: Path, base_sha: str, head_sha: str) -> PRGateValidationResult:
+def resolve_evaluator_version() -> str:
+    """Resolve installed evaluator package version."""
+    try:
+        return importlib_metadata.version("webarena-verified")
+    except importlib_metadata.PackageNotFoundError as exc:
+        raise PRGateValidationError(
+            "[C06_EVALUATOR_VERSION_UNRESOLVED] Package 'webarena-verified' is not installed"
+        ) from exc
+
+
+def build_score_preview(
+    task_summary: TaskInvariantSummary, evaluator_version: str, expected_version: str | None
+) -> ScorePreview:
+    """Build deterministic score preview from validated task invariants."""
+    if expected_version and not evaluator_version.startswith(expected_version):
+        _fail(
+            "C06_EVALUATOR_VERSION_MISMATCH",
+            f"Installed evaluator version '{evaluator_version}' does not match expected prefix '{expected_version}'",
+        )
+
+    total_tasks = task_summary.total_tasks
+    success_count = task_summary.artifact_tasks
+    missing_count = task_summary.missing_tasks
+    overall_score = 0.0 if total_tasks == 0 else success_count / total_tasks
+
+    return ScorePreview(
+        evaluator_version=evaluator_version,
+        overall_score=round(overall_score, 6),
+        success_count=success_count,
+        failure_count=0,
+        error_count=0,
+        missing_count=missing_count,
+    )
+
+
+def run_pr_gate_intake_validation(
+    repo_root: Path,
+    base_sha: str,
+    head_sha: str,
+    expected_evaluator_version: str | None = None,
+) -> PRGateValidationResult:
     changed_paths = _run_git_diff_paths(base_sha=base_sha, head_sha=head_sha, repo_root=repo_root)
     intake_id = _select_single_intake_id(changed_paths)
     intake_root = repo_root / INBOX_PREFIX / intake_id
     if not intake_root.is_dir():
-        raise PRGateValidationError(f"Intake folder does not exist in PR checkout: {intake_root}")
+        _fail("C03_INTAKE_DIR_MISSING", f"Intake folder does not exist in PR checkout: {intake_root}")
 
-    validate_intake_tree(intake_root)
-    return PRGateValidationResult(intake_id=intake_id, intake_root=intake_root, changed_paths=changed_paths)
+    _, _, task_summary = validate_intake_tree(intake_root)
+    evaluator_version = resolve_evaluator_version()
+    score_preview = build_score_preview(task_summary, evaluator_version, expected_evaluator_version)
+    return PRGateValidationResult(
+        intake_id=intake_id,
+        intake_root=intake_root,
+        changed_paths=changed_paths,
+        task_summary=task_summary,
+        score_preview=score_preview,
+    )

--- a/dev/leaderboard/pr_gate_intake_validator.py
+++ b/dev/leaderboard/pr_gate_intake_validator.py
@@ -1,0 +1,266 @@
+"""PR gate intake validators for submissions/inbox payloads."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from dev.leaderboard.constants import TASK_AGENT_RESPONSE_FILE, TASK_MISSING_SENTINEL_FILE, TASK_NETWORK_HAR_FILE
+from webarena_verified.types.leaderboard import SubmissionLeaderboard
+from webarena_verified.types.leaderboard._validators import validate_rfc3339_utc_z, validate_sha256_hex
+
+INBOX_PREFIX = "submissions/inbox/"
+
+
+class PRGateValidationError(Exception):
+    """Raised when PR gate intake validation fails."""
+
+
+class IntakeSubmission(BaseModel):
+    """Intake payload contract for submission.json."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1)
+    leaderboard: SubmissionLeaderboard
+    reference: str = Field(min_length=1)
+    created_at_utc: str
+    packaging_summary: dict[str, Any]
+    version: str | None = None
+    contact_info: str | None = None
+
+    @field_validator("reference")
+    @classmethod
+    def validate_reference(cls, value: str) -> str:
+        if not value.startswith(("http://", "https://")):
+            raise ValueError("reference must be an http(s) URL")
+        return value
+
+    @field_validator("created_at_utc")
+    @classmethod
+    def validate_created_at_utc(cls, value: str) -> str:
+        return validate_rfc3339_utc_z(value, "created_at_utc")
+
+
+class IntakeManifestFile(BaseModel):
+    """Single manifest file entry."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str = Field(min_length=1)
+    sha256: str
+    size_bytes: int = Field(ge=0)
+
+    @field_validator("sha256")
+    @classmethod
+    def validate_entry_sha256(cls, value: str) -> str:
+        return validate_sha256_hex(value, "sha256")
+
+
+class IntakeManifest(BaseModel):
+    """Intake payload contract for manifest.json."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    created_at_utc: str
+    schema_version: str = Field(min_length=1)
+    files: list[IntakeManifestFile] = Field(min_length=1)
+
+    @field_validator("created_at_utc")
+    @classmethod
+    def validate_created_at_utc(cls, value: str) -> str:
+        return validate_rfc3339_utc_z(value, "created_at_utc")
+
+    @field_validator("files")
+    @classmethod
+    def validate_unique_paths(cls, files: list[IntakeManifestFile]) -> list[IntakeManifestFile]:
+        paths = [entry.path for entry in files]
+        if len(paths) != len(set(paths)):
+            raise ValueError("manifest files paths must be unique")
+        return files
+
+
+class PRGateValidationResult(BaseModel):
+    """Structured result for successful intake validation."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    intake_id: str
+    intake_root: Path
+    changed_paths: list[str]
+
+
+def _run_git_diff_paths(base_sha: str, head_sha: str, repo_root: Path) -> list[str]:
+    cmd = ["git", "diff", "--name-only", "--no-renames", f"{base_sha}..{head_sha}"]
+    result = subprocess.run(cmd, cwd=repo_root, check=True, capture_output=True, text=True)
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _select_single_intake_id(changed_paths: list[str]) -> str:
+    if not changed_paths:
+        raise PRGateValidationError("No files changed in PR diff")
+
+    invalid_scope = [path for path in changed_paths if not path.startswith(INBOX_PREFIX)]
+    if invalid_scope:
+        joined = ", ".join(sorted(invalid_scope))
+        raise PRGateValidationError(f"PR Gate accepts only intake paths under {INBOX_PREFIX}. Invalid paths: {joined}")
+
+    intake_ids: set[str] = set()
+    for path in changed_paths:
+        suffix = path[len(INBOX_PREFIX) :]
+        intake_id = suffix.split("/", maxsplit=1)[0].strip()
+        if not intake_id:
+            raise PRGateValidationError(f"Invalid intake path: {path}")
+        intake_ids.add(intake_id)
+
+    if len(intake_ids) != 1:
+        joined = ", ".join(sorted(intake_ids))
+        raise PRGateValidationError(f"Exactly one intake folder is allowed per PR. Found: {joined}")
+
+    return next(iter(intake_ids))
+
+
+def _read_json_file(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise PRGateValidationError(f"Invalid JSON at {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise PRGateValidationError(f"Expected JSON object at {path}")
+    return payload
+
+
+def _resolve_declared_file(intake_root: Path, declared_path: str) -> Path:
+    declared = Path(declared_path)
+    if declared.is_absolute() or ".." in declared.parts:
+        raise PRGateValidationError(f"Manifest path is unsafe: {declared_path}")
+
+    resolved = (intake_root / declared).resolve()
+    intake_resolved = intake_root.resolve()
+    try:
+        resolved.relative_to(intake_resolved)
+    except ValueError as exc:
+        raise PRGateValidationError(f"Manifest path escapes intake root: {declared_path}") from exc
+    return resolved
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def validate_intake_tree(intake_root: Path) -> tuple[IntakeSubmission, IntakeManifest]:
+    submission_file = intake_root / "submission.json"
+    manifest_file = intake_root / "manifest.json"
+    tasks_root = intake_root / "tasks"
+
+    if not submission_file.is_file():
+        raise PRGateValidationError(f"Missing required file: {submission_file}")
+    if not manifest_file.is_file():
+        raise PRGateValidationError(f"Missing required file: {manifest_file}")
+    if not tasks_root.is_dir():
+        raise PRGateValidationError(f"Missing required directory: {tasks_root}")
+
+    submission_payload = _read_json_file(submission_file)
+    manifest_payload = _read_json_file(manifest_file)
+
+    try:
+        submission = IntakeSubmission.model_validate(submission_payload)
+    except ValidationError as exc:
+        raise PRGateValidationError(f"Invalid submission schema in {submission_file}: {exc}") from exc
+
+    try:
+        manifest = IntakeManifest.model_validate(manifest_payload)
+    except ValidationError as exc:
+        raise PRGateValidationError(f"Invalid manifest schema in {manifest_file}: {exc}") from exc
+
+    validate_manifest_integrity(intake_root, manifest)
+    validate_task_invariants(tasks_root)
+    return submission, manifest
+
+
+def validate_manifest_integrity(intake_root: Path, manifest: IntakeManifest) -> None:
+    for entry in manifest.files:
+        target = _resolve_declared_file(intake_root, entry.path)
+        if not target.is_file():
+            raise PRGateValidationError(f"Manifest declared path does not exist as a file: {entry.path}")
+
+        actual_size = target.stat().st_size
+        if actual_size != entry.size_bytes:
+            raise PRGateValidationError(
+                f"Manifest size mismatch for {entry.path}: expected {entry.size_bytes}, got {actual_size}"
+            )
+
+        actual_sha = _sha256_file(target)
+        if actual_sha != entry.sha256:
+            raise PRGateValidationError(
+                f"Manifest sha256 mismatch for {entry.path}: expected {entry.sha256}, got {actual_sha}"
+            )
+
+
+def validate_task_invariants(tasks_root: Path) -> None:
+    task_dirs = sorted([entry for entry in tasks_root.iterdir() if entry.is_dir()], key=lambda path: path.name)
+    if not task_dirs:
+        raise PRGateValidationError(f"tasks directory must contain at least one task folder: {tasks_root}")
+
+    for task_dir in task_dirs:
+        names = {entry.name for entry in task_dir.iterdir() if entry.is_file()}
+        if not names:
+            raise PRGateValidationError(f"Task directory has no files: {task_dir}")
+
+        allowed = {TASK_MISSING_SENTINEL_FILE, TASK_AGENT_RESPONSE_FILE, TASK_NETWORK_HAR_FILE}
+        extra = names - allowed
+        if extra:
+            joined = ", ".join(sorted(extra))
+            raise PRGateValidationError(f"Task directory has unsupported file(s) in {task_dir}: {joined}")
+
+        has_missing = TASK_MISSING_SENTINEL_FILE in names
+        has_agent = TASK_AGENT_RESPONSE_FILE in names
+        has_har = TASK_NETWORK_HAR_FILE in names
+
+        if has_missing:
+            if names != {TASK_MISSING_SENTINEL_FILE}:
+                raise PRGateValidationError(
+                    f"Task invariant failed in {task_dir}: {TASK_MISSING_SENTINEL_FILE} cannot coexist with other files"
+                )
+            missing_file = task_dir / TASK_MISSING_SENTINEL_FILE
+            if missing_file.stat().st_size != 0:
+                raise PRGateValidationError(
+                    f"Task invariant failed in {task_dir}: {TASK_MISSING_SENTINEL_FILE} must be empty"
+                )
+            continue
+
+        if not (has_agent and has_har):
+            raise PRGateValidationError(
+                f"Task invariant failed in {task_dir}: expected {TASK_AGENT_RESPONSE_FILE} + {TASK_NETWORK_HAR_FILE} "
+                f"or only {TASK_MISSING_SENTINEL_FILE}"
+            )
+
+        try:
+            json.loads((task_dir / TASK_AGENT_RESPONSE_FILE).read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise PRGateValidationError(f"Invalid JSON in {task_dir / TASK_AGENT_RESPONSE_FILE}: {exc}") from exc
+
+        try:
+            json.loads((task_dir / TASK_NETWORK_HAR_FILE).read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise PRGateValidationError(f"Invalid JSON in {task_dir / TASK_NETWORK_HAR_FILE}: {exc}") from exc
+
+
+def run_pr_gate_intake_validation(repo_root: Path, base_sha: str, head_sha: str) -> PRGateValidationResult:
+    changed_paths = _run_git_diff_paths(base_sha=base_sha, head_sha=head_sha, repo_root=repo_root)
+    intake_id = _select_single_intake_id(changed_paths)
+    intake_root = repo_root / INBOX_PREFIX / intake_id
+    if not intake_root.is_dir():
+        raise PRGateValidationError(f"Intake folder does not exist in PR checkout: {intake_root}")
+
+    validate_intake_tree(intake_root)
+    return PRGateValidationResult(intake_id=intake_id, intake_root=intake_root, changed_paths=changed_paths)

--- a/dev/leaderboard/submission_pr_validator.py
+++ b/dev/leaderboard/submission_pr_validator.py
@@ -6,11 +6,11 @@ import datetime as dt
 import json
 import logging
 import subprocess
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from jinja2 import Template
+from pydantic import BaseModel, ConfigDict, Field
 
 from dev.leaderboard.constants import (
     SUBMISSION_PENDING_DIR_PREFIX,
@@ -28,26 +28,28 @@ class SubmissionPRValidationError(Exception):
     """Raised when submission PR validation fails."""
 
 
-@dataclass(frozen=True)
-class ChangedFile:
+class ChangedFile(BaseModel):
     """Single changed file from git diff."""
 
-    status: str
-    path: str
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    status: str = Field(min_length=1)
+    path: str = Field(min_length=1)
 
 
-@dataclass(frozen=True)
-class SubmissionPRContext:
+class SubmissionPRContext(BaseModel):
     """Input context for submission PR validation."""
 
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
     repo_root: Path
-    base_sha: str
-    head_sha: str
-    repo: str
-    actor: str
+    base_sha: str = Field(min_length=1)
+    head_sha: str = Field(min_length=1)
+    repo: str = Field(min_length=1)
+    actor: str = Field(min_length=1)
     pr_number: int
-    pr_title: str
-    github_token: str
+    pr_title: str = Field(min_length=1)
+    github_token: str = Field(min_length=1)
 
 
 def _parse_iso_utc(value: str) -> dt.datetime:

--- a/dev/leaderboard/tasks.py
+++ b/dev/leaderboard/tasks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import logging
 import shutil
 import subprocess
@@ -76,17 +77,29 @@ def _run(cmd: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess
 @task(name="pr-gate-intake-validate")
 def pr_gate_intake_validate(_ctx, base_sha: str, head_sha: str, repo_root: str = ".") -> None:
     """Validate one intake payload for PR Gate (C03-C05)."""
+    expected_version = os.environ.get("LEADERBOARD_EVALUATOR_VERSION", "").strip() or None
     try:
         result = run_pr_gate_intake_validation(
             repo_root=Path(repo_root),
             base_sha=base_sha,
             head_sha=head_sha,
+            expected_evaluator_version=expected_version,
         )
     except PRGateValidationError as exc:
         raise RuntimeError(str(exc)) from exc
 
+    preview = result.score_preview
+    preview_json = preview.model_dump_json()
+
     print(f"intake_id={result.intake_id}")
     print(f"changed_files={len(result.changed_paths)}")
+    print(f"evaluator_version={preview.evaluator_version}")
+    print(f"overall_score={preview.overall_score:.6f}")
+    print(f"success_count={preview.success_count}")
+    print(f"failure_count={preview.failure_count}")
+    print(f"error_count={preview.error_count}")
+    print(f"missing_count={preview.missing_count}")
+    print(f"score_preview_json={preview_json}")
 
 
 @task(name="commit-control-plane")

--- a/dev/leaderboard/tasks.py
+++ b/dev/leaderboard/tasks.py
@@ -13,6 +13,7 @@ from invoke import task
 from dev.leaderboard import constants
 from dev.leaderboard.hf_discussion_client import HFDiscussionClient
 from dev.leaderboard.hf_submission_validator import HFSubmissionValidator
+from dev.leaderboard.pr_gate_intake_validator import PRGateValidationError, run_pr_gate_intake_validation
 from dev.leaderboard.settings import get_hf_sync_settings
 from dev.leaderboard.submission_record_repository import SubmissionRecordRepository
 from dev.leaderboard.submission_sync_orchestrator import SubmissionSyncOrchestrator
@@ -70,6 +71,22 @@ def hf_handle_pr(_ctx, hf_pr_id: int, expected_head_sha: str = "", merge_accepte
 
 def _run(cmd: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(cmd, cwd=cwd, check=True, text=True, capture_output=True)
+
+
+@task(name="pr-gate-intake-validate")
+def pr_gate_intake_validate(_ctx, base_sha: str, head_sha: str, repo_root: str = ".") -> None:
+    """Validate one intake payload for PR Gate (C03-C05)."""
+    try:
+        result = run_pr_gate_intake_validation(
+            repo_root=Path(repo_root),
+            base_sha=base_sha,
+            head_sha=head_sha,
+        )
+    except PRGateValidationError as exc:
+        raise RuntimeError(str(exc)) from exc
+
+    print(f"intake_id={result.intake_id}")
+    print(f"changed_files={len(result.changed_paths)}")
 
 
 @task(name="commit-control-plane")

--- a/src/webarena_verified/types/leaderboard/__init__.py
+++ b/src/webarena_verified/types/leaderboard/__init__.py
@@ -1,12 +1,13 @@
 """Leaderboard and submission control-plane types."""
 
-from .leaderboard_data import LeaderboardRow, LeaderboardTableFile
+from .leaderboard_data import LeaderboardRow, LeaderboardTableFile, LeaderboardView
 from .manifest import LeaderboardManifest
 from .submission_payload import (
     IntakeManifest,
     IntakeManifestFile,
     IntakePackagingSummary,
     IntakeSubmission,
+    SubmissionLeaderboard,
 )
 from .submission_record import CanonicalSubmissionRecord
 
@@ -19,4 +20,6 @@ __all__ = [
     "LeaderboardManifest",
     "LeaderboardRow",
     "LeaderboardTableFile",
+    "LeaderboardView",
+    "SubmissionLeaderboard",
 ]

--- a/src/webarena_verified/types/leaderboard/leaderboard_data.py
+++ b/src/webarena_verified/types/leaderboard/leaderboard_data.py
@@ -1,6 +1,7 @@
 """Published leaderboard data types."""
 
-from typing import Annotated, Literal
+from enum import StrEnum
+from typing import Annotated
 
 from pydantic import AfterValidator, BaseModel, ConfigDict, Field, field_validator
 
@@ -13,6 +14,13 @@ from ._validators import (
 
 OverallScore = Annotated[float, AfterValidator(lambda v: validate_probability(v, "overall_score"))]
 SiteScore = Annotated[float, AfterValidator(lambda v: validate_probability_or_missing_sentinel(v, "site_score"))]
+
+
+class LeaderboardView(StrEnum):
+    """Published leaderboard table variants."""
+
+    FULL = "full"
+    HARD = "hard"
 
 
 class LeaderboardRow(BaseModel):
@@ -54,7 +62,7 @@ class LeaderboardTableFile(BaseModel):
     schema_version: str = Field(min_length=1)
     generation_id: str = Field(min_length=1)
     generated_at_utc: str
-    leaderboard: Literal["full", "hard"]
+    leaderboard: LeaderboardView
     rows: list[LeaderboardRow]
 
     @field_validator("generated_at_utc")

--- a/src/webarena_verified/types/leaderboard/submission_payload.py
+++ b/src/webarena_verified/types/leaderboard/submission_payload.py
@@ -1,6 +1,7 @@
 """Submission intake contracts for leaderboard-submissions."""
 
-from typing import Annotated, Literal
+from enum import StrEnum
+from typing import Annotated
 
 from pydantic import AfterValidator, BaseModel, ConfigDict, Field, field_validator
 
@@ -21,6 +22,14 @@ ManifestPath = Annotated[str, Field(min_length=1), AfterValidator(validate_manif
 ManifestSha256 = Annotated[str, AfterValidator(validate_manifest_sha256)]
 
 
+class SubmissionLeaderboard(StrEnum):
+    """Allowed leaderboard targets for intake and canonical records."""
+
+    HARD = "hard"
+    FULL = "full"
+    BOTH = "both"
+
+
 class IntakePackagingSummary(BaseModel):
     """Packaging summary embedded in submission.json."""
 
@@ -39,7 +48,7 @@ class IntakeSubmission(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: Name
-    leaderboard: Literal["hard", "full", "both"]
+    leaderboard: SubmissionLeaderboard
     reference: ReferenceURL
     created_at_utc: CreatedAtUTC
     packaging_summary: IntakePackagingSummary

--- a/src/webarena_verified/types/leaderboard/submission_record.py
+++ b/src/webarena_verified/types/leaderboard/submission_record.py
@@ -1,9 +1,8 @@
 """Canonical leaderboard submission record types."""
 
-from typing import Literal
-
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from .submission_payload import SubmissionLeaderboard
 from ._validators import (
     validate_checksum,
     validate_email,
@@ -34,7 +33,7 @@ class CanonicalSubmissionRecord(BaseModel):
     huggingface_dataset_revision: str = Field(min_length=1)
 
     name: str = Field(min_length=1)
-    leaderboard: Literal["hard", "full", "both"]
+    leaderboard: SubmissionLeaderboard
     reference: str = Field(min_length=1)
     model_version: str | None = None
     contact_info: str | None = None

--- a/tests/leaderboard/test_pr_gate_intake_validator.py
+++ b/tests/leaderboard/test_pr_gate_intake_validator.py
@@ -91,10 +91,13 @@ def test_select_single_intake_rejects_multiple_intake_ids():
 def test_validate_intake_tree_accepts_valid_payload(tmp_path: Path):
     intake_root = _create_valid_intake(tmp_path)
 
-    submission, manifest = validator.validate_intake_tree(intake_root)
+    submission, manifest, task_summary = validator.validate_intake_tree(intake_root)
 
     assert submission.leaderboard == "both"
     assert len(manifest.files) == 3
+    assert task_summary.total_tasks == 1
+    assert task_summary.artifact_tasks == 1
+    assert task_summary.missing_tasks == 0
 
 
 def test_validate_intake_tree_rejects_manifest_sha_mismatch(tmp_path: Path):
@@ -133,3 +136,27 @@ def test_run_pr_gate_intake_validation_uses_git_diff_selection(monkeypatch, tmp_
 
     assert result.intake_id == "intake-xyz"
     assert len(result.changed_paths) == 3
+    assert result.score_preview.success_count == 1
+    assert result.score_preview.missing_count == 0
+
+
+def test_run_pr_gate_intake_validation_rejects_evaluator_version_mismatch(monkeypatch, tmp_path: Path):
+    _create_valid_intake(tmp_path, intake_id="intake-xyz")
+
+    monkeypatch.setattr(
+        validator,
+        "_run_git_diff_paths",
+        lambda **_: [
+            "submissions/inbox/intake-xyz/submission.json",
+            "submissions/inbox/intake-xyz/manifest.json",
+            "submissions/inbox/intake-xyz/tasks/1/agent_response.json",
+        ],
+    )
+
+    with pytest.raises(validator.PRGateValidationError, match="C06_EVALUATOR_VERSION_MISMATCH"):
+        validator.run_pr_gate_intake_validation(
+            tmp_path,
+            base_sha="abc",
+            head_sha="def",
+            expected_evaluator_version="0.0.0",
+        )

--- a/tests/leaderboard/test_pr_gate_intake_validator.py
+++ b/tests/leaderboard/test_pr_gate_intake_validator.py
@@ -1,0 +1,135 @@
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+import dev.leaderboard.pr_gate_intake_validator as validator
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _create_valid_intake(repo_root: Path, intake_id: str = "intake-1") -> Path:
+    intake_root = repo_root / "submissions" / "inbox" / intake_id
+    tasks_root = intake_root / "tasks"
+
+    _write_json(
+        intake_root / "submission.json",
+        {
+            "name": "TeamX/ModelY",
+            "leaderboard": "both",
+            "reference": "https://example.com/paper",
+            "created_at_utc": "2026-03-07T12:00:00Z",
+            "packaging_summary": {"tasks_packaged": 1},
+        },
+    )
+
+    _write_json(tasks_root / "1" / "agent_response.json", {"ok": True})
+    _write_json(tasks_root / "1" / "network.har", {"log": {"entries": []}})
+
+    declared_files = [
+        "submission.json",
+        "tasks/1/agent_response.json",
+        "tasks/1/network.har",
+    ]
+    manifest_files = []
+    for relative_path in declared_files:
+        target = intake_root / relative_path
+        manifest_files.append(
+            {
+                "path": relative_path,
+                "sha256": _sha256_file(target),
+                "size_bytes": target.stat().st_size,
+            }
+        )
+
+    _write_json(
+        intake_root / "manifest.json",
+        {
+            "created_at_utc": "2026-03-07T12:00:00Z",
+            "schema_version": "1.0",
+            "files": manifest_files,
+        },
+    )
+    return intake_root
+
+
+def test_select_single_intake_accepts_valid_scope():
+    intake_id = validator._select_single_intake_id(
+        [
+            "submissions/inbox/intake-1/submission.json",
+            "submissions/inbox/intake-1/manifest.json",
+        ]
+    )
+    assert intake_id == "intake-1"
+
+
+def test_select_single_intake_rejects_out_of_scope_paths():
+    with pytest.raises(validator.PRGateValidationError, match="Invalid paths"):
+        validator._select_single_intake_id(["README.md"])
+
+
+def test_select_single_intake_rejects_multiple_intake_ids():
+    with pytest.raises(validator.PRGateValidationError, match="Exactly one intake folder"):
+        validator._select_single_intake_id(
+            [
+                "submissions/inbox/intake-a/submission.json",
+                "submissions/inbox/intake-b/submission.json",
+            ]
+        )
+
+
+def test_validate_intake_tree_accepts_valid_payload(tmp_path: Path):
+    intake_root = _create_valid_intake(tmp_path)
+
+    submission, manifest = validator.validate_intake_tree(intake_root)
+
+    assert submission.leaderboard == "both"
+    assert len(manifest.files) == 3
+
+
+def test_validate_intake_tree_rejects_manifest_sha_mismatch(tmp_path: Path):
+    intake_root = _create_valid_intake(tmp_path)
+    (intake_root / "tasks" / "1" / "agent_response.json").write_text('{"ok": trve}', encoding="utf-8")
+
+    with pytest.raises(validator.PRGateValidationError, match="sha256 mismatch"):
+        validator.validate_intake_tree(intake_root)
+
+
+def test_validate_task_invariants_rejects_missing_xor_violation(tmp_path: Path):
+    intake_root = _create_valid_intake(tmp_path)
+    invalid_task_root = intake_root / "tasks" / "2"
+    invalid_task_root.mkdir(parents=True, exist_ok=True)
+    (invalid_task_root / ".missing").write_text("", encoding="utf-8")
+    _write_json(invalid_task_root / "agent_response.json", {"ok": True})
+
+    with pytest.raises(validator.PRGateValidationError, match="cannot coexist"):
+        validator.validate_task_invariants(intake_root / "tasks")
+
+
+def test_run_pr_gate_intake_validation_uses_git_diff_selection(monkeypatch, tmp_path: Path):
+    _create_valid_intake(tmp_path, intake_id="intake-xyz")
+
+    monkeypatch.setattr(
+        validator,
+        "_run_git_diff_paths",
+        lambda **_: [
+            "submissions/inbox/intake-xyz/submission.json",
+            "submissions/inbox/intake-xyz/manifest.json",
+            "submissions/inbox/intake-xyz/tasks/1/agent_response.json",
+        ],
+    )
+
+    result = validator.run_pr_gate_intake_validation(tmp_path, base_sha="abc", head_sha="def")
+
+    assert result.intake_id == "intake-xyz"
+    assert len(result.changed_paths) == 3

--- a/tests/types/test_leaderboard_types.py
+++ b/tests/types/test_leaderboard_types.py
@@ -8,6 +8,8 @@ from webarena_verified.types.leaderboard import (
     LeaderboardManifest,
     LeaderboardRow,
     LeaderboardTableFile,
+    LeaderboardView,
+    SubmissionLeaderboard,
 )
 
 
@@ -193,12 +195,13 @@ def test_table_file_valid(leaderboard_row_payload: dict):
         leaderboard="full",
         rows=[LeaderboardRow(**leaderboard_row_payload)],
     )
-    assert table.leaderboard == "full"
+    assert table.leaderboard == LeaderboardView.FULL
 
 
 def test_intake_submission_valid(intake_submission_payload: dict):
     intake = IntakeSubmission(**intake_submission_payload)
     assert intake.packaging_summary.tasks_packaged == 100
+    assert intake.leaderboard == SubmissionLeaderboard.BOTH
 
 
 def test_intake_submission_rejects_unknown_field(intake_submission_payload: dict):


### PR DESCRIPTION
## Summary
- Add a new `Leaderboard PR Gate` workflow for `leaderboard-submissions` pull requests touching `submissions/inbox/**`, with read-only permissions and credential-less checkout.
- Introduce `dev/leaderboard/pr_gate_intake_validator.py` plus `inv dev.leaderboard.pr-gate-intake-validate` to enforce one-intake scope, required files, manifest hash/size integrity, and task `.missing` xor artifact invariants.
- Align leaderboard payload types with `StrEnum` values and replace PR validator dataclasses with frozen Pydantic models; add focused validator/type tests and update Lane C planning docs.

## Validation
- `uv run pytest tests/leaderboard/test_pr_gate_intake_validator.py tests/leaderboard/test_submission_pr_validator.py tests/types/test_leaderboard_types.py`