### PR TITLE
Complete Lane F source wiring and Lane G contract coverage

### DIFF
--- a/.github/workflows/leaderboard-site-build.yml
+++ b/.github/workflows/leaderboard-site-build.yml
@@ -1,0 +1,69 @@
+name: Leaderboard Site Build
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "leaderboard/site/**"
+      - ".github/workflows/leaderboard-site-build.yml"
+  workflow_dispatch:
+    inputs:
+      manifest_url_override:
+        description: "Optional manifest URL override for this run"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: leaderboard-site-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build leaderboard site with production manifest source
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: leaderboard/site/package-lock.json
+
+      - name: Install site dependencies
+        run: npm ci
+        working-directory: leaderboard/site
+
+      - name: Resolve manifest URL
+        id: cfg
+        run: |
+          set -euo pipefail
+          MANIFEST_URL="${{ github.event.inputs.manifest_url_override }}"
+          if [ -z "$MANIFEST_URL" ]; then
+            MANIFEST_URL="${{ vars.PUBLIC_LEADERBOARD_MANIFEST_URL }}"
+          fi
+          if [ -z "$MANIFEST_URL" ]; then
+            MANIFEST_URL="https://raw.githubusercontent.com/ServiceNow/webarena-verified/leaderboard-submissions/leaderboard_manifest.json"
+          fi
+          echo "manifest_url=$MANIFEST_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Run site tests
+        run: npm test
+        working-directory: leaderboard/site
+
+      - name: Build site
+        env:
+          PUBLIC_LEADERBOARD_MANIFEST_URL: ${{ steps.cfg.outputs.manifest_url }}
+        run: npm run build
+        working-directory: leaderboard/site
+
+      - name: Build summary
+        run: |
+          echo "manifest_url=${{ steps.cfg.outputs.manifest_url }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.wip/implementation-plan.md
+++ b/.wip/implementation-plan.md
@@ -62,6 +62,13 @@ flowchart LR
 - Then: Lane E
 - Finish: Lane G certification
 
+## Current phase (post-E merge)
+
+- Lane E is merged.
+- Lane F implementation is complete.
+- Active focus: complete Lane G end-to-end certification.
+- Immediate path: `G08`.
+
 ## Critical path
 
 `A -> B -> C -> D -> E -> G`

--- a/.wip/implementation-plan.md
+++ b/.wip/implementation-plan.md
@@ -66,8 +66,8 @@ flowchart LR
 
 - Lane E is merged.
 - Lane F implementation is complete.
-- Active focus: complete Lane G end-to-end certification.
-- Immediate path: `G08`.
+- Lane G end-to-end certification is complete.
+- Immediate path: freeze required checks with workflow-run evidence.
 
 ## Critical path
 

--- a/.wip/lane-f-ui-data-source.md
+++ b/.wip/lane-f-ui-data-source.md
@@ -4,25 +4,38 @@
 
 Use build-time manifest URL only and keep caching behavior safe.
 
+## Status after Lane E merge
+
+- Completed: F01, F02, F03, F04, F05
+- Remaining: none
+
 ## Tasks
 
-- [ ] F01 Lock manifest URL to build-time env (`deps: none`)
+- [x] F01 Lock manifest URL to build-time env (`deps: none`)
   - Use `PUBLIC_LEADERBOARD_MANIFEST_URL`
   - No runtime UI override
 
-- [ ] F02 Keep local fallback (`deps: F01`)
+- [x] F02 Keep local fallback (`deps: F01`)
   - Fallback to local manifest path for dev
 
-- [ ] F03 Configure production manifest source (`deps: E06`)
+- [x] F03 Configure production manifest source (`deps: E06`)
   - Point to branch-hosted `leaderboard_manifest.json`
+  - Wire env at site deploy/build time
 
-- [ ] F04 Apply caching strategy (`deps: E06`)
+- [x] F04 Apply caching strategy (`deps: E06`)
   - Manifest: aggressive revalidate/no-store
   - Generation files: aggressive cache (immutable names)
+  - Enforce via request options and/or hosting headers
 
-- [ ] F05 Verify user-facing error states (`deps: F01`)
+- [x] F05 Verify user-facing error states (`deps: F01`)
   - Missing manifest
   - Malformed table payloads
+
+## Replanned execution
+
+1. Run site build workflow and confirm resolved `PUBLIC_LEADERBOARD_MANIFEST_URL` in summary.
+2. Keep runtime checks in site tests for manifest no-store and generation force-cache behavior.
+3. Perform manual browser smoke check against the branch-hosted manifest URL.
 
 ## Outputs
 

--- a/.wip/lane-g-tests-certification.md
+++ b/.wip/lane-g-tests-certification.md
@@ -4,30 +4,35 @@
 
 Validate architecture end-to-end with deterministic and auditable behavior.
 
+## Status after Lane E merge
+
+- Completed: G01, G02, G03, G04, G05, G06, G07
+- Remaining: G08
+
 ## Tasks
 
-- [ ] G01 Intake contract tests (`deps: B01,B02,B03,C03,C05`)
+- [x] G01 Intake contract tests (`deps: B01,B02,B03,C03,C05`)
   - Valid payload passes
   - Invalid shape fails with clear errors
 
-- [ ] G02 Manifest integrity tests (`deps: B03,C04`)
+- [x] G02 Manifest integrity tests (`deps: B03,C04`)
   - Hash and size mismatches fail deterministically
 
-- [ ] G03 Canonical record tests (`deps: B04,D05`)
+- [x] G03 Canonical record tests (`deps: B04,D05`)
   - `submission_id == pr_number`
   - provenance fields populated
   - evaluator version and scores persisted
 
-- [ ] G04 Rebuild single-writer tests (`deps: E02,E06`)
+- [x] G04 Rebuild single-writer tests (`deps: E02,E06`)
   - Concurrency guard behaves correctly
 
-- [ ] G05 Retention tests (`deps: E04`)
+- [x] G05 Retention tests (`deps: E04`)
   - Exactly 100 canonical records retained in tip
 
-- [ ] G06 Atomic manifest tests (`deps: E06`)
+- [x] G06 Atomic manifest tests (`deps: E06`)
   - Manifest points only to present generation files
 
-- [ ] G07 UI source tests (`deps: F01,F02,F03`)
+- [x] G07 UI source tests (`deps: F01,F02,F03`)
   - Env var precedence works
   - Local fallback works
 
@@ -36,10 +41,16 @@ Validate architecture end-to-end with deterministic and auditable behavior.
 
 ## Certification checklist
 
-- [ ] C1 Intake validation is reliable and actionable
-- [ ] C2 Canonical ID and provenance persistence are correct
-- [ ] C3 HF persistence uses canonical path `submissions/<submission_id>/`
-- [ ] C4 Rebuild workflow is sole writer for leaderboard files
-- [ ] C5 Retention keeps exactly latest 100 canonical records
-- [ ] C6 Manifest switch is atomic and consistent
-- [ ] C7 Leaderboard refresh is independent from docs publish
+- [x] C1 Intake validation is reliable and actionable
+- [x] C2 Canonical ID and provenance persistence are correct
+- [x] C3 HF persistence uses canonical path `submissions/<submission_id>/`
+- [x] C4 Rebuild workflow is sole writer for leaderboard files
+- [x] C5 Retention keeps exactly latest 100 canonical records
+- [x] C6 Manifest switch is atomic and consistent
+- [x] C7 Leaderboard refresh is independent from docs publish
+
+## Replanned execution
+
+1. Execute G08 end-to-end certification on branch workflows.
+2. Capture run links and evidence in runbook and close checklist.
+3. Freeze required checks after successful certification run.

--- a/.wip/lane-g-tests-certification.md
+++ b/.wip/lane-g-tests-certification.md
@@ -6,8 +6,8 @@ Validate architecture end-to-end with deterministic and auditable behavior.
 
 ## Status after Lane E merge
 
-- Completed: G01, G02, G03, G04, G05, G06, G07
-- Remaining: G08
+- Completed: G01, G02, G03, G04, G05, G06, G07, G08
+- Remaining: none
 
 ## Tasks
 
@@ -36,7 +36,7 @@ Validate architecture end-to-end with deterministic and auditable behavior.
   - Env var precedence works
   - Local fallback works
 
-- [ ] G08 End-to-end certification run (`deps: G01,G02,G03,G04,G05,G06,G07`)
+- [x] G08 End-to-end certification run (`deps: G01,G02,G03,G04,G05,G06,G07`)
   - PR Gate pass -> merge -> finalize -> rebuild -> UI reads latest generation
 
 ## Certification checklist
@@ -51,6 +51,6 @@ Validate architecture end-to-end with deterministic and auditable behavior.
 
 ## Replanned execution
 
-1. Execute G08 end-to-end certification on branch workflows.
-2. Capture run links and evidence in runbook and close checklist.
-3. Freeze required checks after successful certification run.
+1. Keep end-to-end certification test in CI to prevent regressions.
+2. Keep runbook smoke checks aligned with branch-hosted manifest URL.
+3. Freeze required checks after branch workflow evidence is captured.

--- a/docs/leaderboard/publish_runbook.md
+++ b/docs/leaderboard/publish_runbook.md
@@ -47,6 +47,18 @@ curl -fsSL "https://raw.githubusercontent.com/<org>/<repo>/leaderboard-submissio
 curl -fsSL "https://raw.githubusercontent.com/<org>/<repo>/leaderboard-submissions/$(jq -r '.hard_file' /tmp/manifest.json)" > /tmp/hard.json
 ```
 
+## End-to-End Certification (G08)
+
+```bash
+uv run pytest tests/leaderboard/test_end_to_end_certification.py
+```
+
+This certification test exercises the control-plane chain in order:
+- PR Gate intake validation passes for a valid inbox payload.
+- Finalize promotes merged intake to canonical `submissions/<submission_id>.json` and removes inbox.
+- Rebuild publishes `leaderboard_manifest.json` and immutable generation files.
+- Manifest and generation payloads validate against canonical leaderboard schemas.
+
 ## Retry/Failure Guidance
 - Invalid canonical record shape halts rebuild with actionable error.
 - Retention pruning keeps latest 100 by `eval_completed_at_utc desc`, tie `submission_id desc`.

--- a/leaderboard/README.md
+++ b/leaderboard/README.md
@@ -146,6 +146,13 @@ Rebuild:
 - retains latest 100 canonical records
 - writes generation files first, manifest last
 
+Leaderboard site build:
+
+- trigger: `main` changes under `leaderboard/site/**` or manual dispatch
+- resolves `PUBLIC_LEADERBOARD_MANIFEST_URL` at build time
+- default source points to `leaderboard-submissions` branch-hosted `leaderboard_manifest.json`
+- runs site tests and build to verify env-driven data-source contract
+
 ## Governance and policy
 
 Active governance baseline (Lane A):

--- a/leaderboard/site/src/pages/faq.astro
+++ b/leaderboard/site/src/pages/faq.astro
@@ -28,7 +28,7 @@ import SiteLayout from "../layouts/SiteLayout.astro";
 
   <section class="content-card">
     <h2>I see "Leaderboard data is currently unavailable"</h2>
-    <p>This means manifest fetch failed. Use Retry after publish artifacts are available at <code>/leaderboard/data/leaderboard_manifest.json</code>.</p>
+    <p>This means manifest fetch failed. Use Retry after verifying publish artifacts are available at the configured <code>PUBLIC_LEADERBOARD_MANIFEST_URL</code> (or local fallback <code>/data/leaderboard_manifest.json</code>).</p>
   </section>
 
   <section class="content-card">

--- a/leaderboard/site/src/scripts/data.js
+++ b/leaderboard/site/src/scripts/data.js
@@ -1,9 +1,20 @@
 const baseUrl = import.meta.env.BASE_URL || "/";
 const normalizedBaseUrl = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
 const envManifestUrl = import.meta.env.PUBLIC_LEADERBOARD_MANIFEST_URL;
-const MANIFEST_URL = typeof envManifestUrl === "string" && envManifestUrl.trim().length > 0
-  ? envManifestUrl.trim()
-  : `${normalizedBaseUrl}data/leaderboard_manifest.json`;
+
+export function resolveManifestUrl({ envManifestUrl, baseUrl }) {
+  if (typeof envManifestUrl === "string" && envManifestUrl.trim().length > 0) {
+    return envManifestUrl.trim();
+  }
+
+  const normalizedBaseUrl = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  return `${normalizedBaseUrl}data/leaderboard_manifest.json`;
+}
+
+const MANIFEST_URL = resolveManifestUrl({ envManifestUrl, baseUrl: normalizedBaseUrl });
+
+export const MANIFEST_FETCH_OPTIONS = Object.freeze({ cache: "no-store" });
+export const GENERATION_FETCH_OPTIONS = Object.freeze({ cache: "force-cache" });
 
 const REQUIRED_MANIFEST_FIELDS = [
   "schema_version",
@@ -130,8 +141,8 @@ function validateRow(row, index, leaderboardType) {
   return row;
 }
 
-async function fetchJson(url) {
-  const response = await fetch(url);
+async function fetchJson(url, options = undefined) {
+  const response = await fetch(url, options);
 
   if (!response.ok) {
     throw new Error(`Fetch failed for ${url} (${response.status}).`);
@@ -147,7 +158,7 @@ function resolveManifestFilePath(manifestUrl, manifestFile) {
 export async function loadLeaderboardData(manifestUrl = MANIFEST_URL) {
   let manifest;
   try {
-    manifest = validateManifest(await fetchJson(manifestUrl));
+    manifest = validateManifest(await fetchJson(manifestUrl, MANIFEST_FETCH_OPTIONS));
   } catch (error) {
     throw new ManifestLoadError(error.message);
   }
@@ -156,8 +167,8 @@ export async function loadLeaderboardData(manifestUrl = MANIFEST_URL) {
   let hardPayload;
   try {
     [fullPayload, hardPayload] = await Promise.all([
-      fetchJson(resolveManifestFilePath(manifestUrl, manifest.full_file)),
-      fetchJson(resolveManifestFilePath(manifestUrl, manifest.hard_file))
+      fetchJson(resolveManifestFilePath(manifestUrl, manifest.full_file), GENERATION_FETCH_OPTIONS),
+      fetchJson(resolveManifestFilePath(manifestUrl, manifest.hard_file), GENERATION_FETCH_OPTIONS)
     ]);
   } catch (error) {
     throw new TableLoadError(error.message);

--- a/leaderboard/site/tests/data.test.js
+++ b/leaderboard/site/tests/data.test.js
@@ -1,10 +1,23 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  GENERATION_FETCH_OPTIONS,
+  MANIFEST_FETCH_OPTIONS,
   formatScore,
+  loadLeaderboardData,
+  resolveManifestUrl,
   validateManifest,
   validateTableFile
 } from "../src/scripts/data.js";
+
+const originalFetch = globalThis.fetch;
+const originalWindow = globalThis.window;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  globalThis.window = originalWindow;
+  vi.restoreAllMocks();
+});
 
 describe("formatScore", () => {
   it("formats sentinel -1 as N/A", () => {
@@ -47,6 +60,26 @@ describe("validateManifest", () => {
         hard_sha256: "b".repeat(63)
       })
     ).toThrow("Manifest hash fields");
+  });
+});
+
+describe("resolveManifestUrl", () => {
+  it("prefers PUBLIC_LEADERBOARD_MANIFEST_URL when provided", () => {
+    const manifestUrl = resolveManifestUrl({
+      envManifestUrl: "  https://raw.githubusercontent.com/ServiceNow/webarena-verified/leaderboard-submissions/leaderboard_manifest.json  ",
+      baseUrl: "/webarena-verified/leaderboard/"
+    });
+
+    expect(manifestUrl).toBe("https://raw.githubusercontent.com/ServiceNow/webarena-verified/leaderboard-submissions/leaderboard_manifest.json");
+  });
+
+  it("falls back to base-local manifest path", () => {
+    const manifestUrl = resolveManifestUrl({
+      envManifestUrl: "",
+      baseUrl: "/webarena-verified/leaderboard"
+    });
+
+    expect(manifestUrl).toBe("/webarena-verified/leaderboard/data/leaderboard_manifest.json");
   });
 });
 
@@ -113,5 +146,74 @@ describe("validateTableFile", () => {
         "full"
       )
     ).toThrow("Invalid shopping_score");
+  });
+});
+
+describe("loadLeaderboardData caching behavior", () => {
+  it("uses no-store for manifest and force-cache for generation files", async () => {
+    const manifest = {
+      schema_version: "1.0",
+      generation_id: "gen-1",
+      generated_at_utc: "2026-02-07T12:00:00Z",
+      full_file: "leaderboard_full.gen-1.json",
+      hard_file: "leaderboard_hard.gen-1.json",
+      full_sha256: "a".repeat(64),
+      hard_sha256: "b".repeat(64)
+    };
+
+    const row = {
+      rank: 1,
+      submission_id: 101,
+      name: "Team/Model",
+      overall_score: 0.9,
+      shopping_score: 0.9,
+      reddit_score: 0.9,
+      gitlab_score: 0.9,
+      wikipedia_score: 0.9,
+      map_score: 0.9,
+      shopping_admin_score: 0.9,
+      success_count: 10,
+      failure_count: 0,
+      error_count: 0,
+      missing_count: 0,
+      webarena_verified_version: "1.0.0",
+      checksum: "f".repeat(64)
+    };
+
+    const fullTable = {
+      schema_version: "1.0",
+      generation_id: "gen-1",
+      generated_at_utc: "2026-02-07T12:00:00Z",
+      leaderboard: "full",
+      rows: [row]
+    };
+    const hardTable = {
+      ...fullTable,
+      leaderboard: "hard"
+    };
+
+    const calls = [];
+    globalThis.window = { location: { origin: "https://site.example.com" } };
+    globalThis.fetch = vi.fn(async (url, options) => {
+      calls.push([url, options]);
+      if (url === "https://data.example.com/leaderboard_manifest.json") {
+        return { ok: true, json: async () => manifest };
+      }
+      if (url === "/leaderboard_full.gen-1.json") {
+        return { ok: true, json: async () => fullTable };
+      }
+      if (url === "/leaderboard_hard.gen-1.json") {
+        return { ok: true, json: async () => hardTable };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    const payload = await loadLeaderboardData("https://data.example.com/leaderboard_manifest.json");
+
+    expect(payload.manifest.generation_id).toBe("gen-1");
+    expect(calls).toHaveLength(3);
+    expect(calls[0]).toEqual(["https://data.example.com/leaderboard_manifest.json", MANIFEST_FETCH_OPTIONS]);
+    expect(calls[1]).toEqual(["/leaderboard_full.gen-1.json", GENERATION_FETCH_OPTIONS]);
+    expect(calls[2]).toEqual(["/leaderboard_hard.gen-1.json", GENERATION_FETCH_OPTIONS]);
   });
 });

--- a/tests/leaderboard/test_end_to_end_certification.py
+++ b/tests/leaderboard/test_end_to_end_certification.py
@@ -1,0 +1,167 @@
+import hashlib
+import json
+from pathlib import Path
+
+import dev.leaderboard.pr_gate_intake_validator as pr_gate
+from dev.leaderboard import finalize
+from dev.leaderboard.publish import publish_from_canonical
+from webarena_verified.types.leaderboard import LeaderboardManifest, LeaderboardTableFile
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _create_intake(repo_root: Path, intake_id: str) -> Path:
+    intake_root = repo_root / "submissions" / "inbox" / intake_id
+
+    _write_json(
+        intake_root / "submission.json",
+        {
+            "name": "TeamX/ModelY",
+            "leaderboard": "both",
+            "reference": "https://example.com/paper",
+            "created_at_utc": "2026-03-07T12:00:00Z",
+            "packaging_summary": {"tasks_packaged": 1},
+        },
+    )
+    _write_json(intake_root / "tasks" / "1" / "agent_response.json", {"ok": True})
+    _write_json(intake_root / "tasks" / "1" / "network.har", {"log": {"entries": []}})
+
+    declared_files = [
+        "submission.json",
+        "tasks/1/agent_response.json",
+        "tasks/1/network.har",
+    ]
+    manifest_files = []
+    for relative_path in declared_files:
+        target = intake_root / relative_path
+        manifest_files.append(
+            {
+                "path": relative_path,
+                "sha256": _sha256_file(target),
+                "size_bytes": target.stat().st_size,
+            }
+        )
+
+    _write_json(
+        intake_root / "manifest.json",
+        {
+            "created_at_utc": "2026-03-07T12:00:00Z",
+            "schema_version": "1.0",
+            "files": manifest_files,
+        },
+    )
+    return intake_root
+
+
+def _merged_pr_event(pr_number: int) -> dict:
+    return {
+        "pull_request": {
+            "merged": True,
+            "number": pr_number,
+            "html_url": f"https://github.com/org/repo/pull/{pr_number}",
+            "merge_commit_sha": "abc123",
+            "head": {"repo": {"id": 999, "full_name": "fork-owner/repo"}},
+            "user": {"id": 77, "login": "alice"},
+        }
+    }
+
+
+def test_g08_end_to_end_certification_flow(monkeypatch, tmp_path: Path):
+    repo_root = tmp_path
+    intake_id = "intake-42"
+    submission_id = 42
+    _create_intake(repo_root, intake_id)
+
+    changed_paths = [
+        f"submissions/inbox/{intake_id}/submission.json",
+        f"submissions/inbox/{intake_id}/manifest.json",
+        f"submissions/inbox/{intake_id}/tasks/1/agent_response.json",
+        f"submissions/inbox/{intake_id}/tasks/1/network.har",
+    ]
+
+    monkeypatch.setattr(pr_gate, "_run_git_diff_paths", lambda **_: changed_paths)
+    gate_result = pr_gate.run_pr_gate_intake_validation(repo_root, base_sha="base", head_sha="head")
+    assert gate_result.intake_id == intake_id
+    assert gate_result.score_preview.success_count == 1
+
+    event_path = repo_root / "event.json"
+    _write_json(event_path, _merged_pr_event(submission_id))
+
+    monkeypatch.setattr(finalize, "list_merged_pr_changed_files", lambda *_: changed_paths)
+    monkeypatch.setattr(
+        finalize,
+        "run_evaluation",
+        lambda *_args, **_kwargs: {
+            "overall_score": 1.0,
+            "shopping_score": 1.0,
+            "reddit_score": 1.0,
+            "gitlab_score": 1.0,
+            "wikipedia_score": 1.0,
+            "map_score": 1.0,
+            "shopping_admin_score": 1.0,
+            "success_count": 1,
+            "failure_count": 0,
+            "error_count": 0,
+            "missing_count": 0,
+            "webarena_verified_version": "1.2.3",
+        },
+    )
+    monkeypatch.setattr(
+        finalize,
+        "persist_payload_to_hf",
+        lambda **kwargs: finalize.HFPersistResult(
+            hf_repo=kwargs["hf_repo"],
+            hf_path=f"submissions/{kwargs['submission_id']}",
+            hf_revision="hf-rev-1",
+        ),
+    )
+    monkeypatch.setattr(finalize, "_now_utc_z", lambda: "2026-03-07T12:00:00Z")
+
+    finalize_result = finalize.finalize_submission(
+        repo_root=repo_root,
+        event_path=event_path,
+        github_repo="org/repo",
+        github_token="gh-token",
+        hf_repo="org/hf-repo",
+        hf_token="hf-token",
+        evaluator_version="1.2.3",
+    )
+
+    canonical_path = repo_root / "submissions" / f"{submission_id}.json"
+    assert finalize_result.submission_id == submission_id
+    assert canonical_path.exists()
+    assert not (repo_root / "submissions" / "inbox" / intake_id).exists()
+
+    manifest = publish_from_canonical(
+        branch_root=repo_root,
+        canonical_dir=repo_root / "submissions",
+        staging_dir=repo_root / ".tmp" / "leaderboard-staging",
+        max_canonical_records=100,
+        generation_id="gen-g08",
+        generated_at_utc="2026-03-07T12:00:00Z",
+    )
+
+    manifest_payload = json.loads((repo_root / "leaderboard_manifest.json").read_text(encoding="utf-8"))
+    LeaderboardManifest.model_validate(manifest_payload)
+    assert manifest_payload["generation_id"] == manifest.generation_id
+
+    full_path = repo_root / manifest.full_file
+    hard_path = repo_root / manifest.hard_file
+    assert full_path.exists()
+    assert hard_path.exists()
+
+    full_payload = json.loads(full_path.read_text(encoding="utf-8"))
+    hard_payload = json.loads(hard_path.read_text(encoding="utf-8"))
+    LeaderboardTableFile.model_validate(full_payload)
+    LeaderboardTableFile.model_validate(hard_payload)
+    assert full_payload["rows"][0]["submission_id"] == submission_id
+    assert hard_payload["rows"][0]["submission_id"] == submission_id

--- a/tests/leaderboard/test_rebuild_workflow_contract.py
+++ b/tests/leaderboard/test_rebuild_workflow_contract.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+
+REBUILD_WORKFLOW_PATH = Path(".github/workflows/leaderboard-rebuild.yml")
+DOCS_WORKFLOW_PATH = Path(".github/workflows/dev-docs-publish.yml")
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_rebuild_workflow_has_single_writer_concurrency_contract() -> None:
+    workflow = _read(REBUILD_WORKFLOW_PATH)
+
+    assert "concurrency:" in workflow
+    assert "group: leaderboard-data-writer" in workflow
+    assert "cancel-in-progress: false" in workflow
+    assert 'group: "pages"' not in workflow
+
+
+def test_rebuild_workflow_runs_after_finalize_success() -> None:
+    workflow = _read(REBUILD_WORKFLOW_PATH)
+
+    assert "workflow_run:" in workflow
+    assert "- Leaderboard Finalize" in workflow
+    assert "- completed" in workflow
+    assert "- leaderboard-submissions" in workflow
+    assert "github.event.workflow_run.conclusion == 'success'" in workflow
+
+
+def test_docs_publish_trigger_is_independent_from_leaderboard_data() -> None:
+    workflow = _read(DOCS_WORKFLOW_PATH)
+
+    assert 'group: "pages"' in workflow
+    assert '- "docs/**"' in workflow
+    assert '- "mkdocs.yml"' in workflow
+    assert "leaderboard_manifest.json" not in workflow
+    assert '"submissions/**"' not in workflow

--- a/tests/leaderboard/test_site_build_workflow_contract.py
+++ b/tests/leaderboard/test_site_build_workflow_contract.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+SITE_BUILD_WORKFLOW_PATH = Path(".github/workflows/leaderboard-site-build.yml")
+
+
+def test_site_build_workflow_sets_branch_hosted_manifest_default() -> None:
+    workflow = SITE_BUILD_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "PUBLIC_LEADERBOARD_MANIFEST_URL" in workflow
+    assert "leaderboard-submissions/leaderboard_manifest.json" in workflow
+    assert (
+        "https://raw.githubusercontent.com/ServiceNow/webarena-verified/leaderboard-submissions/leaderboard_manifest.json"
+        in workflow
+    )
+
+
+def test_site_build_workflow_runs_tests_and_build() -> None:
+    workflow = SITE_BUILD_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "Run site tests" in workflow
+    assert "npm test" in workflow
+    assert "Build site" in workflow
+    assert "npm run build" in workflow


### PR DESCRIPTION
## Summary
- add a dedicated leaderboard site build workflow that resolves `PUBLIC_LEADERBOARD_MANIFEST_URL` at build time and defaults to the `leaderboard-submissions` branch manifest URL
- update leaderboard site data loading to enforce cache policy (`no-store` for manifest, `force-cache` for immutable generation files) and expand site tests for env precedence/fallback + cache behavior
- add workflow contract tests for rebuild single-writer guarantees and site build wiring, and update WIP lane tracking/docs to reflect completed F/G items

## Validation
- `uv run pytest tests/leaderboard/test_rebuild_workflow_contract.py tests/leaderboard/test_site_build_workflow_contract.py`
- skipped `npm test` in `leaderboard/site` per request