### PR TITLE
Fix route coordinate order for CMU tasks

### DIFF
--- a/assets/dataset/webarena-verified.json
+++ b/assets/dataset/webarena-verified.json
@@ -21374,7 +21374,7 @@
       {
         "evaluator": "NetworkEventEvaluator",
         "ignored_query_params_patterns": [".*"],
-        "expected": {"url": "^.*/route/v1/.*/-75.1718916,39.9011873;-79.9427192,40.4441897.*$"}
+        "expected": {"url": "^.*/route/v1/.*/-79.9427192,40.4441897;-75.1718916,39.9011873.*$"}
       }
     ],
     "revision": 2
@@ -21400,7 +21400,7 @@
       {
         "evaluator": "NetworkEventEvaluator",
         "ignored_query_params_patterns": [".*"],
-        "expected": {"url": "^.*/route/v1/.*/-75.1712951,39.9042046;-79.9427192,40.4441897.*$"}
+        "expected": {"url": "^.*/route/v1/.*/-79.9427192,40.4441897;-75.1712951,39.9042046.*$"}
       }
     ],
     "revision": 2
@@ -21426,7 +21426,7 @@
       {
         "evaluator": "NetworkEventEvaluator",
         "ignored_query_params_patterns": [".*"],
-        "expected": {"url": "^.*/route/v1/.*/-73.9265212,40.8295828;-79.9427192,40.4441897.*$"}
+        "expected": {"url": "^.*/route/v1/.*/-79.9427192,40.4441897;-73.9265212,40.8295828.*$"}
       }
     ],
     "revision": 2
@@ -21452,7 +21452,7 @@
       {
         "evaluator": "NetworkEventEvaluator",
         "ignored_query_params_patterns": [".*"],
-        "expected": {"url": "^.*/route/v1/.*/-73.9935443,40.7505085;-79.9427192,40.4441897.*$"}
+        "expected": {"url": "^.*/route/v1/.*/-79.9427192,40.4441897;-73.9935443,40.7505085.*$"}
       }
     ],
     "revision": 2
@@ -21478,7 +21478,7 @@
       {
         "evaluator": "NetworkEventEvaluator",
         "ignored_query_params_patterns": [".*"],
-        "expected": {"url": "^.*/route/v1/.*/-71.0621475,42.3662922;-79.9427192,40.4441897.*$"}
+        "expected": {"url": "^.*/route/v1/.*/-79.9427192,40.4441897;-71.0621475,42.3662922.*$"}
       }
     ],
     "revision": 2

--- a/tests/dataset/test_dataset_integrity.py
+++ b/tests/dataset/test_dataset_integrity.py
@@ -112,6 +112,15 @@ def test_eval_config(task_id: int, dataset_by_task_id: dict[int, dict[str, Any]]
             )
 
 
+@pytest.mark.parametrize("task_id", range(737, 742))
+def test_cmu_route_tasks_start_at_cmu(task_id: int, dataset_by_task_id: dict[int, dict[str, Any]]) -> None:
+    """OSRM route coordinates must follow the origin-to-destination order in the intent."""
+    task = dataset_by_task_id[task_id]
+    network_eval = next(evaluation for evaluation in task["eval"] if evaluation["evaluator"] == "NetworkEventEvaluator")
+
+    assert "/-79.9427192,40.4441897;" in network_eval["expected"]["url"]
+
+
 def test_intent_template_consistency(
     intent_template_id: int,
     tasks_by_intent_template_id: dict[int, list[dict[str, Any]]],


### PR DESCRIPTION
## Summary\n\n- correct OSRM coordinate order for routing tasks 737–741 so Carnegie Mellon University is the origin\n- add a regression test covering all five tasks\n\n## Validation\n\n- ============================= test session starts ==============================
platform darwin -- Python 3.11.15, pytest-9.0.1, pluggy-1.6.0
rootdir: /Users/Krug/Desktop/ChatGPT/webarena-verified
configfile: pyproject.toml
plugins: playwright-0.7.2, anyio-4.12.0, base-url-2.1.0, rerunfailures-16.1, cov-7.0.0
collected 1820 items

tests/dataset/test_dataset_integrity.py ................................ [  1%]
........................................................................ [  5%]
........................................................................ [  9%]
........................................................................ [ 13%]
........................................................................ [ 17%]
........................................................................ [ 21%]
........................................................................ [ 25%]
........................................................................ [ 29%]
........................................................................ [ 33%]
........................................................................ [ 37%]
........................................................................ [ 41%]
........................................................................ [ 45%]
........................................................................ [ 49%]
........................................................................ [ 53%]
........................................................................ [ 57%]
........................................................................ [ 61%]
........................................................................ [ 65%]
........................................................................ [ 69%]
........................................................................ [ 72%]
........................................................................ [ 76%]
........................................................................ [ 80%]
........................................................................ [ 84%]
........................................................................ [ 88%]
........................................................................ [ 92%]
........................................................................ [ 96%]
............................................................             [100%]

============================= 1820 passed in 1.54s ============================= (1,820 passed)\n- 
╭──────────────────────────────────── LINT ────────────────────────────────────╮
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯

  Running ruff check...
All checks passed!
  Running ruff format check...
195 files already formatted
  Running ty check...
All checks passed!
  Running actionlint...

✓ All checks passed\n- ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
ty.......................................................................Passed\n\nCloses #6